### PR TITLE
WORK-23446 Modified timing calculations for pages and entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## v0.13.103
+
+### Details
+Various modifications to how timing is calculated.
+
+### Bug Fix
+* Changing page load/domLoad event handling to only accept the first events.  Other events are for other pages and inflate the timing incorrectly.
+* Introduced a custom event for tracking when a request was continued in order to decrease the overall time calculation for a page or tag load.
+
+### Breaking Changes
+
+### Jira Issues
+[WORK-23446] (https://observepoint.atlassian.net/browse/WORK-23446)
+
 ## v0.13.102
 
 ### Details

--- a/lib/har.js
+++ b/lib/har.js
@@ -34,8 +34,9 @@ function parsePage(pageId, stats) {
     const wallTimeMs = firstRequest.wallTime * 1000;
     const startedDateTime = new Date(wallTimeMs).toISOString();
     // page timings
-    const onContentLoad = stats.domContentEventFiredMs - stats.firstRequestMs;
-    const onLoad = stats.loadEventFiredMs - stats.firstRequestMs;
+    const startTime = stats.requestContinuedMs || stats.firstRequestMs;
+    const onContentLoad = stats.domContentEventFiredMs - startTime;
+    const onLoad = stats.loadEventFiredMs - startTime;
     // process this page load entries
     const entries = [...stats.entries.values()]
         .map((entry) => parseEntry(pageId, entry))
@@ -218,9 +219,10 @@ function computeTimings(entry) {
     const timing = entry.responseParams.response.timing;
     // compute the total duration (including blocking time)
     const finishedTimestamp = entry.responseFinishedS || entry.responseFailedS;
-    const time = toMilliseconds(finishedTimestamp - entry.requestParams.timestamp);
+    const startTimestamp = entry.requestContinuedS || entry.requestParams.timestamp;
+    const time = toMilliseconds(finishedTimestamp - startTimestamp);
     // compute individual components
-    const blockedBase = toMilliseconds(timing.requestTime - entry.requestParams.timestamp);
+    const blockedBase = toMilliseconds(timing.requestTime - startTimestamp);
     const blockedStart = firstNonNegative([
         timing.dnsStart, timing.connectStart, timing.sendStart
     ]);

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -7,6 +7,7 @@ class Stats {
         this.url = url;
         this.firstRequestId = undefined;
         this.firstRequestMs = undefined;
+        this.requestContinuedMs = undefined;
         this.domContentEventFiredMs = undefined;
         this.loadEventFiredMs = undefined;
         this.entries = new Map();
@@ -41,16 +42,32 @@ class Stats {
         }
     }
 
+    _Custom_requestContinued(fulfill, reject, params) {
+        const {timestamp, requestId} = params;
+        if (this.firstRequestId === requestId) {
+            this.requestContinuedMs = timestamp * 1000;
+        }
+        const entry = this.entries.get(requestId);
+        if (!entry) {
+            return;
+        }
+        entry.requestContinuedS = timestamp;
+    }
+
     _Page_domContentEventFired(fulfill, reject, params) {
         const {timestamp} = params;
-        this.domContentEventFiredMs = timestamp * 1000;
+        if (!this.domContentEventFiredMs) {
+            this.domContentEventFiredMs = timestamp * 1000;
+        }
         // check termination condition
         this._checkFinished(fulfill);
     }
 
     _Page_loadEventFired(fulfill, reject, params) {
         const {timestamp} = params;
-        this.loadEventFiredMs = timestamp * 1000;
+        if (!this.loadEventFiredMs) {
+            this.loadEventFiredMs = timestamp * 1000;
+        }
         // check termination condition
         this._checkFinished(fulfill);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@observepoint/chrome-har-capturer",
-    "version": "0.13.102",
+    "version": "0.13.103",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@observepoint/chrome-har-capturer",
-            "version": "0.13.102",
+            "version": "0.13.103",
             "license": "MIT",
             "dependencies": {
                 "chalk": "1.x.x",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "headless"
     ],
     "homepage": "https://github.com/observepoint/chrome-har-capturer",
-    "version": "0.13.102",
+    "version": "0.13.103",
     "repository": {
         "type": "git",
         "url": "git://github.com/observepoint/chrome-har-capturer"

--- a/test/offline.js
+++ b/test/offline.js
@@ -8,6 +8,23 @@ const fs = require('fs');
 
 const log = JSON.parse(fs.readFileSync('test/log.json'));
 
+const timingLog = JSON.parse(fs.readFileSync('test/timingLog.json'));
+
+const validatePageTime = (har, thresholdTimeMs) => {
+    const domEvent = har.log.pages[0].pageTimings.onContentLoad;
+    const loadEvent = har.log.pages[0].pageTimings.onLoad;
+    if (thresholdTimeMs <= domEvent || thresholdTimeMs <= loadEvent) {
+        throw {message: `Page timings did not meet required thresholds. Threshold: ${thresholdTimeMs}, load was ${loadEvent}, domEvent was ${domEvent}`};
+    }
+};
+
+const validateEntryTime = (har, url, thresholdTimeMs) => {
+    const httpRequestEntry = har.log.entries.find((entry) => entry.time !== -1 && entry.request.url === url);
+    if (thresholdTimeMs <= httpRequestEntry.time) {
+        throw {message: `Entry timings did not meet required thresholds. Threshold was ${thresholdTimeMs}, event time was ${httpRequestEntry.time}, entry url${url}`};
+    }
+};
+
 describe('HAR (offline)', () => {
     it('Parse event log without content', async () => {
         return CHC.fromLog('http://someurl', log).then((har) => {
@@ -30,5 +47,35 @@ describe('HAR (offline)', () => {
         }).catch((err) => {
             return true;
         });
+    });
+
+    // Testing the efficacy of using a requestContinued event vs using natural timings.
+    // The timingLog.json file has artificially exaggerated natural start times (subtracted 300 seconds) for the page and a single test entry.
+    it('Parse timestamps with no requestContinued messages', async () => {
+        const filteredLog = timingLog.filter(entry => entry.method !== 'Custom.requestContinued');
+        return CHC.fromLog('https://www.apple.com/', filteredLog, { content: true })
+            .then((har) => {
+                return validate.har(har);
+            });
+    });
+    it('Parse timestamps with requestContinued messages', async () => {
+        const testTag = 'https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_iphone_image__ko7x4isga4ia_large.svg';
+        return CHC.fromLog('https://www.apple.com/', timingLog, { content: true })
+            .then((har) => {
+                return validate.har(har) && validatePageTime(har, 300000) && validateEntryTime(har, testTag, 300000);
+            });
+    });
+
+    // Testing to ensure only the first instances of page events are considered.
+    // The timingLog.json file has subsequent page events which are artificially exaggerated by 300 seconds in timing.
+    it('Only accept the first Page.loadEventFired and Page.domContentEventFired', async () => {
+        const filteredLog = timingLog.filter(entry => entry.method !== 'Custom.requestContinued');
+        // Counteracting the artificial padding of the page start times.
+        timingLog[0].params.timestamp += 300;
+        timingLog[0].params.wallTime += 300;
+        return CHC.fromLog('https://www.apple.com/', filteredLog, { content: true })
+            .then((har) => {
+                return validate.har(har) && validatePageTime(har, 300000);
+            });
     });
 });

--- a/test/timingLog.json
+++ b/test/timingLog.json
@@ -1,0 +1,22886 @@
+[
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47019.314526,
+      "wallTime": 1671216603.715455,
+      "initiator": {
+        "type": "other"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Document",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47320.09031,
+      "type": "Document",
+      "response": {
+        "url": "https://www.apple.com/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "cache-control": "max-age=0",
+          "content-encoding": "gzip",
+          "content-length": "18387",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "content-type": "text/html; charset=utf-8",
+          "date": "Fri, 16 Dec 2022 18:55:04 GMT",
+          "expires": "Fri, 16 Dec 2022 18:55:04 GMT",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "server": "Apple",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "vary": "Accept-Encoding",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "mimeType": "text/html",
+        "connectionReused": false,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 772,
+        "timing": {
+          "requestTime": 47319.843616,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 6.927,
+          "dnsEnd": 24.398,
+          "connectStart": 24.398,
+          "connectEnd": 169.273,
+          "sslStart": 66.117,
+          "sslEnd": 169.241,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 169.42,
+          "sendEnd": 169.538,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 243.21
+        },
+        "responseTime": 1671216904486.507,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47320.098435,
+      "dataLength": 103001,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47320.098369,
+      "encodedDataLength": 19222,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": {
+      "timestamp": 47321.201769
+    }
+  },
+  {
+    "method": "Page.loadEventFired",
+    "params": {
+      "timestamp": 47322.710095
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "wallTime": 1671216903.985,
+      "timestamp": 47319.584070920944
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47329.571279,
+      "wallTime": 1671216913.97357,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "",
+              "scriptId": "38",
+              "url": "pptr://__puppeteer_evaluation_script__",
+              "lineNumber": 0,
+              "columnNumber": 16
+            }
+          ]
+        }
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Document",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.139547,
+      "type": "Document",
+      "response": {
+        "url": "https://www.apple.com/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "cache-control": "max-age=0",
+          "content-encoding": "gzip",
+          "content-length": "18387",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "content-type": "text/html; charset=utf-8",
+          "date": "Fri, 16 Dec 2022 18:55:14 GMT",
+          "expires": "Fri, 16 Dec 2022 18:55:14 GMT",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "server": "Apple",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "vary": "Accept-Encoding",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "mimeType": "text/html",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 744,
+        "timing": {
+          "requestTime": 47330.08255,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 2.782,
+          "sendEnd": 3.581,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 53.998
+        },
+        "responseTime": 1671216914537.008,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.149047,
+      "dataLength": 103001,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.141122,
+      "encodedDataLength": 19194,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": {
+      "timestamp": 47930.845888
+    }
+  },
+  {
+    "method": "Page.loadEventFired",
+    "params": {
+      "timestamp": 47931.40621
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "wallTime": 1671216914.228,
+      "timestamp": 47329.82707095146
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.2",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.10048,
+      "wallTime": 1671216904.501698,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 100,
+        "columnNumber": 101
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.2",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.044422,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "ntcoent-length": "116297",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=0",
+          "content-length": "12667",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:05 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 720,
+        "timing": {
+          "requestTime": 47320.605153,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.301,
+          "sendEnd": 0.457,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 438.376
+        },
+        "responseTime": 1671216905444.293,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.2",
+      "timestamp": 47321.044456,
+      "dataLength": 116297,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.2",
+      "timestamp": 47321.046011,
+      "dataLength": 0,
+      "encodedDataLength": 12721
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.2",
+      "timestamp": 47321.044113,
+      "encodedDataLength": 13441,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.2",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.2",
+      "wallTime": 1671216904.752,
+      "timestamp": 47320.35107111931
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.3",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/localnav/6/styles/ac-localnav.built.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.10108,
+      "wallTime": 1671216904.501937,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 101,
+        "columnNumber": 93
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.3",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.023112,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/ac/localnav/6/styles/ac-localnav.built.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "text/css",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "cache-control": "max-age=52",
+          "content-length": "7086",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:57 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 699,
+        "timing": {
+          "requestTime": 47320.609082,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.129,
+          "sendEnd": 0.219,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 413.288
+        },
+        "responseTime": 1671216905423.135,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.3",
+      "timestamp": 47321.023143,
+      "dataLength": 80101,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.3",
+      "timestamp": 47321.024543,
+      "dataLength": 0,
+      "encodedDataLength": 7122
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.3",
+      "timestamp": 47321.022713,
+      "encodedDataLength": 7821,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.3",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.3",
+      "wallTime": 1671216904.753,
+      "timestamp": 47320.35207104683
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.4",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalfooter/7/en_US/styles/ac-globalfooter.built.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.101201,
+      "wallTime": 1671216904.502066,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 102,
+        "columnNumber": 107
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.4",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.006712,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/ac/globalfooter/7/en_US/styles/ac-globalfooter.built.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css",
+          "nncoection": "close",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=0",
+          "content-length": "5342",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:05 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 704,
+        "timing": {
+          "requestTime": 47320.60956,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.13,
+          "sendEnd": 0.248,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 393.404
+        },
+        "responseTime": 1671216905403.504,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.4",
+      "timestamp": 47321.007825,
+      "dataLength": 45448,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.4",
+      "timestamp": 47321.010501,
+      "dataLength": 0,
+      "encodedDataLength": 5378
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.4",
+      "timestamp": 47321.007515,
+      "encodedDataLength": 6082,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.4",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.4",
+      "wallTime": 1671216904.754,
+      "timestamp": 47320.35307097435
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.5",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.101314,
+      "wallTime": 1671216904.502174,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 157,
+        "columnNumber": 107
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.5",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.007708,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "1169",
+          "x-xss-protection": "1; mode=block",
+          "cteonnt-length": "22124",
+          "server": "Apple",
+          "etag": "3031aa1b654ca979f7577e4706173d35a9d8ff35cbdb80a8e4911fd9423e2bc4",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css;charset=UTF-8",
+          "cache-control": "max-age=2162",
+          "expires": "Fri, 16 Dec 2022 19:31:07 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 779,
+        "timing": {
+          "requestTime": 47320.61005,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.13,
+          "sendEnd": 0.197,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 395.945
+        },
+        "responseTime": 1671216905406.688,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.5",
+      "timestamp": 47321.010555,
+      "dataLength": 22124,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.5",
+      "timestamp": 47321.01817,
+      "dataLength": 0,
+      "encodedDataLength": 1187
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.5",
+      "timestamp": 47321.017816,
+      "encodedDataLength": 1975,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.5",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.5",
+      "wallTime": 1671216904.755,
+      "timestamp": 47320.35407114029
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.6",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.101422,
+      "wallTime": 1671216904.502277,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 158,
+        "columnNumber": 88
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.6",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47320.857538,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "44956",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 16 Dec 2022 00:11:20 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css",
+          "cache-control": "max-age=77",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:22 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 768,
+        "timing": {
+          "requestTime": 47320.610479,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.094,
+          "sendEnd": 0.164,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 243.001
+        },
+        "responseTime": 1671216905253.876,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.858248,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.858317,
+      "dataLength": 62922,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.865197,
+      "dataLength": 65536,
+      "encodedDataLength": 10582
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.865269,
+      "dataLength": 48720,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.865302,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.86541,
+      "dataLength": 69071,
+      "encodedDataLength": 11350
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.887054,
+      "dataLength": 29720,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.910055,
+      "dataLength": 235327,
+      "encodedDataLength": 2707
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.913851,
+      "dataLength": 65536,
+      "encodedDataLength": 7752
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.913912,
+      "dataLength": 71145,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.915549,
+      "dataLength": 60057,
+      "encodedDataLength": 8531
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.918238,
+      "dataLength": 0,
+      "encodedDataLength": 4160
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.6",
+      "timestamp": 47320.915538,
+      "encodedDataLength": 45850,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.6",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.6",
+      "wallTime": 1671216904.755,
+      "timestamp": 47320.35407114029
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.7",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/built/scripts/head.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.101544,
+      "wallTime": 1671216904.502401,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 159,
+        "columnNumber": 93
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.7",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47320.88686,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/built/scripts/head.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "5548",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:51 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=77",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:22 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 778,
+        "timing": {
+          "requestTime": 47320.610907,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.086,
+          "sendEnd": 0.136,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 274.598
+        },
+        "responseTime": 1671216905286.2,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.7",
+      "timestamp": 47320.887154,
+      "dataLength": 6393,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.7",
+      "timestamp": 47320.888979,
+      "dataLength": 14749,
+      "encodedDataLength": 5575
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.7",
+      "timestamp": 47320.888951,
+      "encodedDataLength": 6353,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.7",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.7",
+      "wallTime": 1671216904.755,
+      "timestamp": 47320.35407114029
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.8",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.10172,
+      "wallTime": 1671216904.502576,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 341,
+        "columnNumber": 89
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.8",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.02777,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "application/x-javascript",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=0",
+          "content-length": "26946",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:05 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 710,
+        "timing": {
+          "requestTime": 47320.611904,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.09,
+          "sendEnd": 0.15,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 414.989
+        },
+        "responseTime": 1671216905427.647,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.8",
+      "timestamp": 47321.028453,
+      "dataLength": 38783,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.8",
+      "timestamp": 47321.038833,
+      "dataLength": 54191,
+      "encodedDataLength": 27036
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.8",
+      "timestamp": 47321.03971,
+      "dataLength": 7982,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.8",
+      "timestamp": 47321.03884,
+      "encodedDataLength": 27746,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.8",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.8",
+      "wallTime": 1671216904.756,
+      "timestamp": 47320.35507106781
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.9",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.101847,
+      "wallTime": 1671216904.502702,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 345,
+        "columnNumber": 106
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.9",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.102594,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "x-content-type-options": "nosniff",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/x-javascript",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=10",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:15 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 736,
+        "timing": {
+          "requestTime": 47320.612478,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.09,
+          "sendEnd": 0.365,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 457.49
+        },
+        "responseTime": 1671216905470.752,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.9",
+      "timestamp": 47321.102613,
+      "dataLength": 327242,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.9",
+      "timestamp": 47321.107407,
+      "dataLength": 0,
+      "encodedDataLength": 77332
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.9",
+      "timestamp": 47321.090597,
+      "encodedDataLength": 78068,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.9",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.9",
+      "wallTime": 1671216904.756,
+      "timestamp": 47320.35507106781
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.10",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalfooter/7/en_US/scripts/ac-globalfooter.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.101983,
+      "wallTime": 1671216904.502838,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1397,
+        "columnNumber": 95
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.10",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.008515,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/ac/globalfooter/7/en_US/scripts/ac-globalfooter.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "ntcoent-length": "6983",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "cneonction": "close",
+          "content-length": "2482",
+          "x-xss-protection": "1; mode=block",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=0",
+          "expires": "Fri, 16 Dec 2022 18:55:05 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 756,
+        "timing": {
+          "requestTime": 47320.612683,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.174,
+          "sendEnd": 0.235,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 393.903
+        },
+        "responseTime": 1671216905407.257,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.10",
+      "timestamp": 47321.018474,
+      "dataLength": 6983,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.10",
+      "timestamp": 47321.019338,
+      "dataLength": 0,
+      "encodedDataLength": 2509
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.10",
+      "timestamp": 47321.018435,
+      "encodedDataLength": 3265,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.10",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.10",
+      "wallTime": 1671216904.757,
+      "timestamp": 47320.35607099533
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.11",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.102197,
+      "wallTime": 1671216904.503061,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1444,
+        "columnNumber": 96
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.11",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.088373,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "cneonction": "close",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=162",
+          "expires": "Fri, 16 Dec 2022 18:57:47 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 765,
+        "timing": {
+          "requestTime": 47320.616308,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.127,
+          "sendEnd": 0.475,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 432.951
+        },
+        "responseTime": 1671216905450.036,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.11",
+      "timestamp": 47321.088405,
+      "dataLength": 176336,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.11",
+      "timestamp": 47321.104735,
+      "dataLength": 16155,
+      "encodedDataLength": 56300
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.11",
+      "timestamp": 47321.090435,
+      "encodedDataLength": 57065,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.11",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.11",
+      "wallTime": 1671216904.757,
+      "timestamp": 47320.35607099533
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.12",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.102341,
+      "wallTime": 1671216904.503196,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1477,
+        "columnNumber": 93
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.12",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47320.909904,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "56738",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:51 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=332",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:00:37 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 779,
+        "timing": {
+          "requestTime": 47320.61667,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.151,
+          "sendEnd": 0.216,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 289.125
+        },
+        "responseTime": 1671216905306.397,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47320.918313,
+      "dataLength": 12725,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47320.921812,
+      "dataLength": 30483,
+      "encodedDataLength": 12902
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47320.930952,
+      "dataLength": 52242,
+      "encodedDataLength": 11737
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47320.942598,
+      "dataLength": 32399,
+      "encodedDataLength": 8531
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47321.005828,
+      "dataLength": 35491,
+      "encodedDataLength": 8531
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47321.011352,
+      "dataLength": 4548,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47321.019878,
+      "dataLength": 25917,
+      "encodedDataLength": 905
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47321.035688,
+      "dataLength": 32132,
+      "encodedDataLength": 14294
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.12",
+      "timestamp": 47321.035632,
+      "encodedDataLength": 57679,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.12",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.12",
+      "wallTime": 1671216904.76,
+      "timestamp": 47320.35907101631
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.13",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/ac-films/6.8.2/styles/modal.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.102508,
+      "wallTime": 1671216904.503364,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1479,
+        "columnNumber": 68
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.13",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.102266,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/ac/ac-films/6.8.2/styles/modal.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "ntcoent-length": "111126",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "content-length": "16768",
+          "x-xss-protection": "1; mode=block",
+          "x-cache-remote": "TCP_IMS_HIT from a184-30-41-158.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css",
+          "cache-control": "max-age=300",
+          "expires": "Fri, 16 Dec 2022 19:00:05 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 805,
+        "timing": {
+          "requestTime": 47320.617133,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.083,
+          "sendEnd": 0.229,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 447.367
+        },
+        "responseTime": 1671216905465.271,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.13",
+      "timestamp": 47321.102287,
+      "dataLength": 111126,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.13",
+      "timestamp": 47321.102441,
+      "dataLength": 0,
+      "encodedDataLength": 16831
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.13",
+      "timestamp": 47321.065384,
+      "encodedDataLength": 17636,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.13",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.13",
+      "wallTime": 1671216904.76,
+      "timestamp": 47320.35907101631
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.14",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/ac-films/6.8.2/scripts/autofilms.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.102881,
+      "wallTime": 1671216904.503744,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1480,
+        "columnNumber": 83
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.14",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.104589,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/ac/ac-films/6.8.2/scripts/autofilms.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "application/x-javascript",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=109",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:56:54 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 704,
+        "timing": {
+          "requestTime": 47320.617308,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.093,
+          "sendEnd": 0.144,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 471.99
+        },
+        "responseTime": 1671216905490.053,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.14",
+      "timestamp": 47321.104611,
+      "dataLength": 99963,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.14",
+      "timestamp": 47321.116778,
+      "dataLength": 70254,
+      "encodedDataLength": 87208
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.14",
+      "timestamp": 47321.11684,
+      "dataLength": 181326,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.14",
+      "timestamp": 47321.124903,
+      "dataLength": 60731,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.14",
+      "timestamp": 47321.108748,
+      "encodedDataLength": 87912,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.14",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.14",
+      "wallTime": 1671216904.76,
+      "timestamp": 47320.35907101631
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.15",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/metrics/data-relay/1.1.4/scripts/data-relay.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.103041,
+      "wallTime": 1671216904.503896,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1483,
+        "columnNumber": 101
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.15",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.019051,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/metrics/data-relay/1.1.4/scripts/data-relay.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "application/x-javascript",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=0",
+          "content-length": "4955",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:05 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 712,
+        "timing": {
+          "requestTime": 47320.619455,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.076,
+          "sendEnd": 0.125,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 398.608
+        },
+        "responseTime": 1671216905418.806,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.15",
+      "timestamp": 47321.019094,
+      "dataLength": 15652,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.15",
+      "timestamp": 47321.019834,
+      "dataLength": 0,
+      "encodedDataLength": 4991
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.15",
+      "timestamp": 47321.018753,
+      "encodedDataLength": 5703,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.15",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.15",
+      "wallTime": 1671216904.761,
+      "timestamp": 47320.36007094383
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.16",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/metrics/data-relay/1.1.4/scripts/auto-relay.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47320.103178,
+      "wallTime": 1671216904.504036,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1484,
+        "columnNumber": 101
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.16",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.008887,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/metrics/data-relay/1.1.4/scripts/auto-relay.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=52",
+          "content-length": "197",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:57 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 693,
+        "timing": {
+          "requestTime": 47320.619759,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.07,
+          "sendEnd": 0.174,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 387.233
+        },
+        "responseTime": 1671216905407.738,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.16",
+      "timestamp": 47321.019239,
+      "dataLength": 197,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.16",
+      "timestamp": 47321.019749,
+      "dataLength": 0,
+      "encodedDataLength": 215
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.16",
+      "timestamp": 47321.019061,
+      "encodedDataLength": 908,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.16",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.16",
+      "wallTime": 1671216904.761,
+      "timestamp": 47320.36007094383
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.176",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_apple_image__b5er5ngrzxqq_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.061923,
+      "wallTime": 1671216905.462786,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.176",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.611613,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_apple_image__b5er5ngrzxqq_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cneonction": "close",
+          "nncoection": "close",
+          "content-length": "506",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Sun, 24 Oct 2021 03:40:19 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=73",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:19 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 767,
+        "timing": {
+          "requestTime": 47321.566561,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.166,
+          "sendEnd": 0.268,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.14
+        },
+        "responseTime": 1671216906011.45,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.176",
+      "timestamp": 47321.611648,
+      "dataLength": 863,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.176",
+      "timestamp": 47321.613259,
+      "dataLength": 0,
+      "encodedDataLength": 524
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.176",
+      "timestamp": 47321.610992,
+      "encodedDataLength": 1291,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.176",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.176",
+      "wallTime": 1671216905.714,
+      "timestamp": 47321.3130710125
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.177",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_store_image__c7jy08initqq_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.062163,
+      "wallTime": 1671216905.463011,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.177",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.612203,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_store_image__c7jy08initqq_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "962",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=426",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:02:12 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 728,
+        "timing": {
+          "requestTime": 47321.567038,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.178,
+          "sendEnd": 0.284,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.071
+        },
+        "responseTime": 1671216906011.89,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.177",
+      "timestamp": 47321.612227,
+      "dataLength": 2512,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.177",
+      "timestamp": 47321.615551,
+      "dataLength": 0,
+      "encodedDataLength": 980
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.177",
+      "timestamp": 47321.611275,
+      "encodedDataLength": 1708,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.177",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.177",
+      "wallTime": 1671216905.714,
+      "timestamp": 47321.3130710125
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.178",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_mac_image__dazlko3t9a6a_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.062288,
+      "wallTime": 1671216905.463131,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.178",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.616103,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_mac_image__dazlko3t9a6a_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "598",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=78",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:24 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 739,
+        "timing": {
+          "requestTime": 47321.567122,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.134,
+          "sendEnd": 0.202,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 48.028
+        },
+        "responseTime": 1671216906015.905,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.178",
+      "timestamp": 47321.616129,
+      "dataLength": 1105,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.178",
+      "timestamp": 47321.616798,
+      "dataLength": 0,
+      "encodedDataLength": 616
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.178",
+      "timestamp": 47321.615385,
+      "encodedDataLength": 1355,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.178",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.178",
+      "wallTime": 1671216905.714,
+      "timestamp": 47321.3130710125
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.179",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_ipad_image__fw9qyj9lloi2_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.062396,
+      "wallTime": 1671216905.463239,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.179",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.617066,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_ipad_image__fw9qyj9lloi2_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "content-length": "634",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=63",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:09 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 753,
+        "timing": {
+          "requestTime": 47321.567562,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.092,
+          "sendEnd": 0.174,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 47.959
+        },
+        "responseTime": 1671216906016.294,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.179",
+      "timestamp": 47321.617098,
+      "dataLength": 1164,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.179",
+      "timestamp": 47321.617534,
+      "dataLength": 0,
+      "encodedDataLength": 652
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.179",
+      "timestamp": 47321.615791,
+      "encodedDataLength": 1405,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.179",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.179",
+      "wallTime": 1671216905.715,
+      "timestamp": 47321.31407094002
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.180",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_iphone_image__ko7x4isga4ia_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47021.062493,
+      "wallTime": 1671216605.463336,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.180",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.617818,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_iphone_image__ko7x4isga4ia_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "692",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=81",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:27 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 728,
+        "timing": {
+          "requestTime": 47321.567744,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.078,
+          "sendEnd": 0.121,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 48.145
+        },
+        "responseTime": 1671216906016.671,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.180",
+      "timestamp": 47321.617836,
+      "dataLength": 1405,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.180",
+      "timestamp": 47321.618375,
+      "dataLength": 0,
+      "encodedDataLength": 710
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.180",
+      "timestamp": 47321.616061,
+      "encodedDataLength": 1438,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.180",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.180",
+      "wallTime": 1671216905.715,
+      "timestamp": 47321.31407094002
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.181",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_watch_image__gkoblojrlsqe_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.062593,
+      "wallTime": 1671216905.463436,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.181",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.61356,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_watch_image__gkoblojrlsqe_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "unused62": "8096267",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "nncoection": "close",
+          "content-length": "683",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=49",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:55:55 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 767,
+        "timing": {
+          "requestTime": 47321.569217,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.079,
+          "sendEnd": 0.138,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 42.157
+        },
+        "responseTime": 1671216906012.155,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.181",
+      "timestamp": 47321.613581,
+      "dataLength": 1309,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.181",
+      "timestamp": 47321.614108,
+      "dataLength": 0,
+      "encodedDataLength": 701
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.181",
+      "timestamp": 47321.611523,
+      "encodedDataLength": 1468,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.181",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.181",
+      "wallTime": 1671216905.715,
+      "timestamp": 47321.31407094002
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.122",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_semibold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.072922,
+      "wallTime": 1671216905.473785,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.122",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.121514,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_semibold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:55:06 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=1572",
+          "content-length": "234260",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:21:18 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 719,
+        "timing": {
+          "requestTime": 47322.079473,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.111,
+          "sendEnd": 0.226,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 41.434
+        },
+        "responseTime": 1671216906521.666,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.122",
+      "timestamp": 47322.122051,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.122",
+      "timestamp": 47322.131806,
+      "dataLength": 15476,
+      "encodedDataLength": 81201
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.122",
+      "timestamp": 47322.131842,
+      "dataLength": 65536,
+      "encodedDataLength": 153590
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.122",
+      "timestamp": 47322.134808,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.122",
+      "timestamp": 47322.13483,
+      "dataLength": 22176,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.122",
+      "timestamp": 47322.134844,
+      "encodedDataLength": 235510,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.122",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.122",
+      "wallTime": 1671216906.227,
+      "timestamp": 47321.82607102394
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.146",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_regular.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.073088,
+      "wallTime": 1671216905.47393,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.146",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.125048,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_regular.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:55:05 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=1975",
+          "content-length": "220536",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:28:01 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 719,
+        "timing": {
+          "requestTime": 47322.079631,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.075,
+          "sendEnd": 0.099,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.974
+        },
+        "responseTime": 1671216906525.382,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.146",
+      "timestamp": 47322.126205,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.146",
+      "timestamp": 47322.132102,
+      "dataLength": 74887,
+      "encodedDataLength": 75067
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.146",
+      "timestamp": 47322.142167,
+      "dataLength": 80113,
+      "encodedDataLength": 145973
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.146",
+      "timestamp": 47322.135147,
+      "encodedDataLength": 221759,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.146",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.146",
+      "wallTime": 1671216906.228,
+      "timestamp": 47321.82707095146
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.183",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_airpods_image__f969s84ivmaa_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.093436,
+      "wallTime": 1671216905.494289,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.183",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.661109,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_airpods_image__f969s84ivmaa_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "content-length": "854",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=98",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:44 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 753,
+        "timing": {
+          "requestTime": 47321.599015,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.089,
+          "sendEnd": 0.155,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.524
+        },
+        "responseTime": 1671216906061.329,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.183",
+      "timestamp": 47321.661129,
+      "dataLength": 1722,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.183",
+      "timestamp": 47321.664615,
+      "dataLength": 0,
+      "encodedDataLength": 872
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.183",
+      "timestamp": 47321.660664,
+      "encodedDataLength": 1625,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.183",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.183",
+      "wallTime": 1671216905.745,
+      "timestamp": 47321.34407091141
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.184",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_tvhome_image__zb2ewyxbi6ae_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.093578,
+      "wallTime": 1671216905.49442,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.184",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.664774,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_tvhome_image__zb2ewyxbi6ae_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "1072",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=107",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:53 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 728,
+        "timing": {
+          "requestTime": 47321.599391,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.071,
+          "sendEnd": 0.157,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.388
+        },
+        "responseTime": 1671216906061.561,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.184",
+      "timestamp": 47321.664789,
+      "dataLength": 2194,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.184",
+      "timestamp": 47321.665139,
+      "dataLength": 0,
+      "encodedDataLength": 1090
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.184",
+      "timestamp": 47321.660961,
+      "encodedDataLength": 1818,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.184",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.184",
+      "wallTime": 1671216905.745,
+      "timestamp": 47321.34407091141
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.185",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_onlyonapple_image__c4t8k97tougm_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.093679,
+      "wallTime": 1671216905.494528,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.185",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.665309,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_onlyonapple_image__c4t8k97tougm_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' data: blob: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "1209",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=533",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:03:59 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 724,
+        "timing": {
+          "requestTime": 47321.599552,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.064,
+          "sendEnd": 0.105,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.504
+        },
+        "responseTime": 1671216906061.854,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.185",
+      "timestamp": 47321.665322,
+      "dataLength": 3177,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.185",
+      "timestamp": 47321.665691,
+      "dataLength": 0,
+      "encodedDataLength": 1227
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.185",
+      "timestamp": 47321.661153,
+      "encodedDataLength": 1951,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.185",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.185",
+      "wallTime": 1671216905.745,
+      "timestamp": 47321.34407091141
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.186",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_accessories_image__edj0wqmfwxyu_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.09378,
+      "wallTime": 1671216905.494621,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.186",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.665827,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_accessories_image__edj0wqmfwxyu_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cneonction": "close",
+          "nncoection": "close",
+          "content-length": "1066",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=431",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:02:17 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 767,
+        "timing": {
+          "requestTime": 47321.599856,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.084,
+          "sendEnd": 0.142,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.366
+        },
+        "responseTime": 1671216906062.025,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.186",
+      "timestamp": 47321.665839,
+      "dataLength": 3656,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.186",
+      "timestamp": 47321.66612,
+      "dataLength": 0,
+      "encodedDataLength": 1084
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.186",
+      "timestamp": 47321.661318,
+      "encodedDataLength": 1851,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.186",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.186",
+      "wallTime": 1671216905.746,
+      "timestamp": 47321.34507107735
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.187",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_support_image__bw9kctll7u3m_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.093873,
+      "wallTime": 1671216905.494715,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.187",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.666284,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_support_image__bw9kctll7u3m_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "content-length": "869",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=350",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:00:56 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 753,
+        "timing": {
+          "requestTime": 47321.600218,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.073,
+          "sendEnd": 0.119,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.15
+        },
+        "responseTime": 1671216906062.173,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.187",
+      "timestamp": 47321.666298,
+      "dataLength": 1934,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.187",
+      "timestamp": 47321.666572,
+      "dataLength": 0,
+      "encodedDataLength": 887
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.187",
+      "timestamp": 47321.661454,
+      "encodedDataLength": 1640,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.187",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.187",
+      "wallTime": 1671216905.746,
+      "timestamp": 47321.34507107735
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.188",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_search_image__cbllq1gkias2_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.093964,
+      "wallTime": 1671216905.494804,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.188",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.666706,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_search_image__cbllq1gkias2_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "251",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=79",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:25 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 727,
+        "timing": {
+          "requestTime": 47321.600398,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.058,
+          "sendEnd": 0.101,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.146
+        },
+        "responseTime": 1671216906062.337,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.188",
+      "timestamp": 47321.666718,
+      "dataLength": 541,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.188",
+      "timestamp": 47321.667015,
+      "dataLength": 0,
+      "encodedDataLength": 269
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.188",
+      "timestamp": 47321.661665,
+      "encodedDataLength": 996,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.188",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.188",
+      "wallTime": 1671216905.746,
+      "timestamp": 47321.34507107735
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.189",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_bag_image__yzte50i47ciu_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.094077,
+      "wallTime": 1671216905.494924,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.189",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.667168,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_bag_image__yzte50i47ciu_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "content-length": "298",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=93",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:39 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 753,
+        "timing": {
+          "requestTime": 47321.600773,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.068,
+          "sendEnd": 0.112,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 60.978
+        },
+        "responseTime": 1671216906062.548,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.189",
+      "timestamp": 47321.667179,
+      "dataLength": 477,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.189",
+      "timestamp": 47321.667483,
+      "dataLength": 0,
+      "encodedDataLength": 316
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.189",
+      "timestamp": 47321.661854,
+      "encodedDataLength": 1069,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.189",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.189",
+      "wallTime": 1671216905.746,
+      "timestamp": 47321.34507107735
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.190",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/us/shop/bag/status?apikey=SFX9YPYY9PPXCU9KH",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.101753,
+      "wallTime": 1671216905.502632,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 1884
+            },
+            {
+              "functionName": "x",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 1628
+            },
+            {
+              "functionName": "",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 2750
+            }
+          ],
+          "parent": {
+            "description": "Promise.then",
+            "callFrames": [
+              {
+                "functionName": "C",
+                "scriptId": "15",
+                "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+                "lineNumber": 0,
+                "columnNumber": 2478
+              },
+              {
+                "functionName": "getStoreState",
+                "scriptId": "15",
+                "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+                "lineNumber": 0,
+                "columnNumber": 4202
+              },
+              {
+                "functionName": "v._initializeStore",
+                "scriptId": "15",
+                "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+                "lineNumber": 0,
+                "columnNumber": 67758
+              },
+              {
+                "functionName": "_",
+                "scriptId": "15",
+                "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+                "lineNumber": 0,
+                "columnNumber": 63748
+              },
+              {
+                "functionName": "84.85",
+                "scriptId": "15",
+                "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+                "lineNumber": 0,
+                "columnNumber": 63315
+              },
+              {
+                "functionName": "s",
+                "scriptId": "15",
+                "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+                "lineNumber": 0,
+                "columnNumber": 253
+              },
+              {
+                "functionName": "t",
+                "scriptId": "15",
+                "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+                "lineNumber": 0,
+                "columnNumber": 413
+              },
+              {
+                "functionName": "",
+                "scriptId": "15",
+                "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+                "lineNumber": 0,
+                "columnNumber": 430
+              }
+            ]
+          }
+        }
+      },
+      "redirectHasExtraInfo": false,
+      "type": "XHR",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.190",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.660825,
+      "type": "XHR",
+      "response": {
+        "url": "https://www.apple.com/us/shop/bag/status?apikey=SFX9YPYY9PPXCU9KH",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "frame-ancestors 'self'",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "x-shred": "88444471a30633f7523a9f056b432b2b",
+          "content-length": "118",
+          "x-xss-protection": "1; mode=block",
+          "x-request-id": "7a1f324b-af2d-459d-b129-8150d1d23c89",
+          "pragma": "no-cache",
+          "last-modified": "Fri, 16 Dec 2022 18:52:12 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-language": "en-US",
+          "content-type": "application/json",
+          "cache-control": "private, no-cache, no-store, must-revalidate",
+          "expires": "Fri, 16 Dec 2022 18:55:06 GMT"
+        },
+        "mimeType": "application/json",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 476,
+        "timing": {
+          "requestTime": 47321.604671,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.079,
+          "sendEnd": 0.132,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 55.623
+        },
+        "responseTime": 1671216906061.064,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.190",
+      "timestamp": 47321.660857,
+      "dataLength": 137,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.190",
+      "timestamp": 47321.664064,
+      "dataLength": 0,
+      "encodedDataLength": 136
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.190",
+      "timestamp": 47321.660451,
+      "encodedDataLength": 612,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.190",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.190",
+      "wallTime": 1671216905.753,
+      "timestamp": 47321.35207104683
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.194",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/localeswitcher/4/en_US/content/localeswitcher.json",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.136689,
+      "wallTime": 1671216905.537552,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "value",
+              "scriptId": "17",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 180076
+            },
+            {
+              "functionName": "e",
+              "scriptId": "17",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 179268
+            },
+            {
+              "functionName": "175.176",
+              "scriptId": "17",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 178568
+            },
+            {
+              "functionName": "i",
+              "scriptId": "17",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 253
+            },
+            {
+              "functionName": "e",
+              "scriptId": "17",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 413
+            },
+            {
+              "functionName": "",
+              "scriptId": "17",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 430
+            }
+          ]
+        }
+      },
+      "redirectHasExtraInfo": false,
+      "type": "XHR",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.194",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.681465,
+      "type": "XHR",
+      "response": {
+        "url": "https://www.apple.com/ac/localeswitcher/4/en_US/content/localeswitcher.json",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' data: blob: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "392",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:29 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/json",
+          "cache-control": "max-age=70",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:16 GMT"
+        },
+        "mimeType": "application/json",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 724,
+        "timing": {
+          "requestTime": 47321.63954,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.11,
+          "sendEnd": 0.171,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 41.43
+        },
+        "responseTime": 1671216906081.753,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.194",
+      "timestamp": 47321.681491,
+      "dataLength": 1331,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.194",
+      "timestamp": 47321.682104,
+      "dataLength": 0,
+      "encodedDataLength": 410
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.194",
+      "timestamp": 47321.681147,
+      "encodedDataLength": 1134,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.194",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.194",
+      "wallTime": 1671216905.788,
+      "timestamp": 47321.38707113266
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.196",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-card-december/card_logo__b0k9gna8xemu_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.14648,
+      "wallTime": 1671216905.54733,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.196",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.709043,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-card-december/card_logo__b0k9gna8xemu_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=1837",
+          "accept-ranges": "bytes",
+          "content-length": "2934",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:25:43 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 749,
+        "timing": {
+          "requestTime": 47321.66197,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.298,
+          "sendEnd": 0.443,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.279
+        },
+        "responseTime": 1671216906109.053,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.196",
+      "timestamp": 47321.709058,
+      "dataLength": 2934,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.196",
+      "timestamp": 47321.709597,
+      "dataLength": 0,
+      "encodedDataLength": 2961
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.196",
+      "timestamp": 47321.708323,
+      "encodedDataLength": 3710,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.196",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.196",
+      "wallTime": 1671216905.797,
+      "timestamp": 47321.396070957184
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.197",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/airpods-holiday-2022/promo_logo_airpods_holiday__uzkw355klvmy_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.146973,
+      "wallTime": 1671216905.547817,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.197",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.709323,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/airpods-holiday-2022/promo_logo_airpods_holiday__uzkw355klvmy_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=2792",
+          "accept-ranges": "bytes",
+          "content-length": "815",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:41:38 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 749,
+        "timing": {
+          "requestTime": 47321.662001,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.292,
+          "sendEnd": 0.443,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.418
+        },
+        "responseTime": 1671216906109.226,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.197",
+      "timestamp": 47321.709335,
+      "dataLength": 815,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.197",
+      "timestamp": 47321.709779,
+      "dataLength": 0,
+      "encodedDataLength": 833
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.197",
+      "timestamp": 47321.708508,
+      "encodedDataLength": 1582,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.197",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.197",
+      "wallTime": 1671216905.798,
+      "timestamp": 47321.39707112312
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.198",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-watch-series-8/promo_logo_apple_watch_series_8__ee6riplsucuq_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.147126,
+      "wallTime": 1671216905.547965,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.198",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.709477,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-watch-series-8/promo_logo_apple_watch_series_8__ee6riplsucuq_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=2487",
+          "accept-ranges": "bytes",
+          "content-length": "2785",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:36:33 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 749,
+        "timing": {
+          "requestTime": 47321.662025,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.282,
+          "sendEnd": 0.42,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.532
+        },
+        "responseTime": 1671216906109.364,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.198",
+      "timestamp": 47321.709489,
+      "dataLength": 2785,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.198",
+      "timestamp": 47321.709534,
+      "dataLength": 0,
+      "encodedDataLength": 2812
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.198",
+      "timestamp": 47321.708638,
+      "encodedDataLength": 3561,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.198",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.198",
+      "wallTime": 1671216905.798,
+      "timestamp": 47321.39707112312
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.199",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-watch-ultra/promo_logo_apple_watch_ultra__ebzaahharnue_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.147268,
+      "wallTime": 1671216905.548107,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.199",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.709682,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-watch-ultra/promo_logo_apple_watch_ultra__ebzaahharnue_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=3046",
+          "accept-ranges": "bytes",
+          "content-length": "2311",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:45:52 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 749,
+        "timing": {
+          "requestTime": 47321.662074,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.247,
+          "sendEnd": 0.371,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.623
+        },
+        "responseTime": 1671216906109.505,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.199",
+      "timestamp": 47321.709692,
+      "dataLength": 2311,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.199",
+      "timestamp": 47321.709724,
+      "dataLength": 0,
+      "encodedDataLength": 2329
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.199",
+      "timestamp": 47321.708765,
+      "encodedDataLength": 3078,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.199",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.199",
+      "wallTime": 1671216905.798,
+      "timestamp": 47321.39707112312
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.200",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/arcade/logo_light__cfvl40z2nzau_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.147421,
+      "wallTime": 1671216905.54826,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.200",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.708505,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/arcade/logo_light__cfvl40z2nzau_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=3280",
+          "accept-ranges": "bytes",
+          "content-length": "2497",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:49:46 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 749,
+        "timing": {
+          "requestTime": 47321.662098,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.236,
+          "sendEnd": 0.348,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 45.902
+        },
+        "responseTime": 1671216906108.782,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.200",
+      "timestamp": 47321.708525,
+      "dataLength": 2497,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.200",
+      "timestamp": 47321.709202,
+      "dataLength": 0,
+      "encodedDataLength": 2515
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.200",
+      "timestamp": 47321.708181,
+      "encodedDataLength": 3264,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.200",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.200",
+      "wallTime": 1671216905.798,
+      "timestamp": 47321.39707112312
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.68",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_semibold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.148881,
+      "wallTime": 1671216905.549783,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.68",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.199782,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_semibold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:47 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=1649",
+          "content-length": "231048",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:22:35 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 719,
+        "timing": {
+          "requestTime": 47322.152018,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.114,
+          "sendEnd": 0.18,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.533
+        },
+        "responseTime": 1671216906599.352,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.68",
+      "timestamp": 47322.199797,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.68",
+      "timestamp": 47322.208372,
+      "dataLength": 3530,
+      "encodedDataLength": 69228
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.68",
+      "timestamp": 47322.208393,
+      "dataLength": 65536,
+      "encodedDataLength": 162351
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.68",
+      "timestamp": 47322.217327,
+      "dataLength": 96446,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.68",
+      "timestamp": 47322.21164,
+      "encodedDataLength": 232298,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.68",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.68",
+      "wallTime": 1671216906.301,
+      "timestamp": 47321.900071144104
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.92",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_regular.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.148998,
+      "wallTime": 1671216905.549837,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.92",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.202694,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_regular.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:47 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=1326",
+          "content-length": "215624",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:17:12 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 719,
+        "timing": {
+          "requestTime": 47322.155355,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.077,
+          "sendEnd": 0.135,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.909
+        },
+        "responseTime": 1671216906603.049,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.92",
+      "timestamp": 47322.203032,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.92",
+      "timestamp": 47322.208186,
+      "dataLength": 66153,
+      "encodedDataLength": 66306
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.92",
+      "timestamp": 47322.21143,
+      "dataLength": 65536,
+      "encodedDataLength": 149813
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.92",
+      "timestamp": 47322.211448,
+      "dataLength": 18399,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.92",
+      "timestamp": 47322.211463,
+      "encodedDataLength": 216838,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.92",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.92",
+      "wallTime": 1671216906.304,
+      "timestamp": 47321.903070926666
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.173",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Icons/v3/sf-pro-icons_regular.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.149042,
+      "wallTime": 1671216905.549882,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.173",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.199017,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Icons/v3/sf-pro-icons_regular.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:50 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=936",
+          "content-length": "11208",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:10:42 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 720,
+        "timing": {
+          "requestTime": 47322.155635,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.081,
+          "sendEnd": 0.132,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 42.632
+        },
+        "responseTime": 1671216906599.028,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.173",
+      "timestamp": 47322.19905,
+      "dataLength": 11208,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.173",
+      "timestamp": 47322.199623,
+      "dataLength": 0,
+      "encodedDataLength": 11253
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.173",
+      "timestamp": 47322.198483,
+      "encodedDataLength": 11973,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.173",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.173",
+      "wallTime": 1671216906.305,
+      "timestamp": 47321.904071092606
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.205",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/a_voEGGOjHGvUUhwrbStXQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.178183,
+      "wallTime": 1671216905.579035,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.205",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.787776,
+      "type": "Image",
+      "response": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/a_voEGGOjHGvUUhwrbStXQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "S4WPP7BREK7236BIRDVI5N7QCM",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "972cf7fc3122bfadf82888ea8eb7f013",
+          "x-daiquiri-instance": "daiquiri:13624002:mr85p00it-hyhk03094901:7987:22HOTFIX10:daiquiri-amp-processing-shared-int-001-mr",
+          "cdnuuid": "2a43a61a-5e3c-49b3-a1c0-fc69934bb5b9-1986660428",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "972cf7fc3122bfadf82888ea8eb7f013-95c935128de9cfd6",
+          "content-length": "150240",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Tue, 15 Nov 2022 09:47:36 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY4NTA1NjU2NzQ5LGlzQnVpbGRWZXJzaW9uTm90U2V0LDUwMDY4LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "972cf7fc-3122-bfad-f828-88ea8eb7f013",
+          "x-b3-spanid": "95c935128de9cfd6",
+          "cache-control": "no-transform, max-age=13429930",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": false,
+        "connectionId": 206,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 805,
+        "timing": {
+          "requestTime": 47321.683015,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.341,
+          "dnsEnd": 24.083,
+          "connectStart": 24.083,
+          "connectEnd": 83.457,
+          "sslStart": 40.056,
+          "sslEnd": 83.454,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 83.914,
+          "sendEnd": 84.03,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 104.37
+        },
+        "responseTime": 1671216906188.177,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.788566,
+      "dataLength": 3244,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.791538,
+      "dataLength": 2810,
+      "encodedDataLength": 3262
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.798512,
+      "dataLength": 8439,
+      "encodedDataLength": 2819
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.807971,
+      "dataLength": 27339,
+      "encodedDataLength": 35850
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.810184,
+      "dataLength": 2810,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.81448,
+      "dataLength": 20872,
+      "encodedDataLength": 2819
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.826601,
+      "dataLength": 65536,
+      "encodedDataLength": 20917
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.828414,
+      "dataLength": 13749,
+      "encodedDataLength": 66724
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.830497,
+      "dataLength": 5441,
+      "encodedDataLength": 12741
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.83068,
+      "dataLength": 0,
+      "encodedDataLength": 5459
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.205",
+      "timestamp": 47321.830501,
+      "encodedDataLength": 151396,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.205",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.205",
+      "wallTime": 1671216905.83,
+      "timestamp": 47321.429070949554
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.206",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is5-ssl.mzstatic.com/image/thumb/lgskq6n1xkUI5DOyA5tWWQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.178411,
+      "wallTime": 1671216905.579251,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.206",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.796928,
+      "type": "Image",
+      "response": {
+        "url": "https://is5-ssl.mzstatic.com/image/thumb/lgskq6n1xkUI5DOyA5tWWQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "TDXTAGLZB3XZI2AJLIAKINC2H4",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "98ef3019790eef9468095a00a4345a3f",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE175:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "5e97e60b-50e2-4ae6-88da-9d1655ff6eee-2705293982",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "98ef3019790eef9468095a00a4345a3f-bbff866c81eddd39",
+          "content-length": "118817",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Fri, 02 Dec 2022 13:04:39 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY5OTg2Mjc5NzAyLGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMDk3LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "98ef3019-790e-ef94-6809-5a00a4345a3f",
+          "x-b3-spanid": "bbff866c81eddd39",
+          "cache-control": "no-transform, max-age=15502754",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": false,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 809,
+        "timing": {
+          "requestTime": 47321.683128,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.032,
+          "dnsEnd": 24.222,
+          "connectStart": 24.222,
+          "connectEnd": 81.529,
+          "sslStart": 40.071,
+          "sslEnd": 81.524,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 81.741,
+          "sendEnd": 81.831,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 113.245
+        },
+        "responseTime": 1671216906197.147,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.206",
+      "timestamp": 47321.80756,
+      "dataLength": 38925,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.206",
+      "timestamp": 47321.81728,
+      "dataLength": 34207,
+      "encodedDataLength": 39024
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.206",
+      "timestamp": 47321.820462,
+      "dataLength": 16989,
+      "encodedDataLength": 34279
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.206",
+      "timestamp": 47321.825098,
+      "dataLength": 22925,
+      "encodedDataLength": 17025
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.206",
+      "timestamp": 47321.826253,
+      "dataLength": 5771,
+      "encodedDataLength": 22979
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.206",
+      "timestamp": 47321.826501,
+      "dataLength": 0,
+      "encodedDataLength": 5789
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.206",
+      "timestamp": 47321.826279,
+      "encodedDataLength": 119905,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.206",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.206",
+      "wallTime": 1671216905.83,
+      "timestamp": 47321.429070949554
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.207",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/GT66HoV8VJL1IZwaqos_TQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.178523,
+      "wallTime": 1671216905.579361,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.207",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.785721,
+      "type": "Image",
+      "response": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/GT66HoV8VJL1IZwaqos_TQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "P62AXEJW67XW23G4TQ4CR5FI64",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "7fb40b9136f7ef6d6cdc9c3828f4a8f7",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE104:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "bccc1c4a-6cf0-4f75-afe8-2ce87a180321-671224242",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "7fb40b9136f7ef6d6cdc9c3828f4a8f7-c59fd132c7681c6a",
+          "content-length": "170028",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Mon, 15 Aug 2022 04:52:47 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjYwNTM5MTY3MDY5LGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMTc5LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "7fb40b91-36f7-ef6d-6cdc-9c3828f4a8f7",
+          "x-b3-spanid": "c59fd132c7681c6a",
+          "cache-control": "no-transform, max-age=11619582",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 206,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 805,
+        "timing": {
+          "requestTime": 47321.683295,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 83.659,
+          "sendEnd": 83.75,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 102.021
+        },
+        "responseTime": 1671216906186.104,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.207",
+      "timestamp": 47321.786884,
+      "dataLength": 7625,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.207",
+      "timestamp": 47321.79183,
+      "dataLength": 1571,
+      "encodedDataLength": 7652
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.207",
+      "timestamp": 47321.834976,
+      "dataLength": 65536,
+      "encodedDataLength": 1571
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.207",
+      "timestamp": 47321.840145,
+      "dataLength": 62484,
+      "encodedDataLength": 70078
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.207",
+      "timestamp": 47321.842697,
+      "dataLength": 30788,
+      "encodedDataLength": 58230
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.207",
+      "timestamp": 47321.848644,
+      "dataLength": 2024,
+      "encodedDataLength": 30851
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.207",
+      "timestamp": 47321.848832,
+      "dataLength": 0,
+      "encodedDataLength": 2042
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.207",
+      "timestamp": 47321.848651,
+      "encodedDataLength": 171229,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.207",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.207",
+      "wallTime": 1671216905.83,
+      "timestamp": 47321.429070949554
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.208",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/IZLh7W9XMi2iYTPqqFwRYg/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.178624,
+      "wallTime": 1671216905.579463,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.208",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.806704,
+      "type": "Image",
+      "response": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/IZLh7W9XMi2iYTPqqFwRYg/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "BMUAKDJJWLTO7PITBHESLU22VQ",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "0b28050d29b2e6efbd1309c925d35aac",
+          "x-daiquiri-instance": "daiquiri:13624002:mr85p00it-hyhk03094901:7987:22RELEASE175:daiquiri-amp-processing-shared-int-001-mr",
+          "cdnuuid": "57e0bcaa-bd59-4467-9caa-e63b9e24c1f3-1566828557",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "0b28050d29b2e6efbd1309c925d35aac-0bbb274d1ff57879",
+          "content-length": "144789",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Fri, 02 Dec 2022 02:01:06 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY5OTQ2NDY2MTcyLGlzQnVpbGRWZXJzaW9uTm90U2V0LDUwMTQ1LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "0b28050d-29b2-e6ef-bd13-09c925d35aac",
+          "x-b3-spanid": "0bbb274d1ff57879",
+          "cache-control": "no-transform, max-age=15059708",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 206,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 807,
+        "timing": {
+          "requestTime": 47321.708807,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 58.162,
+          "sendEnd": 58.239,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 97.358
+        },
+        "responseTime": 1671216906206.925,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.208",
+      "timestamp": 47321.847066,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.208",
+      "timestamp": 47321.857108,
+      "dataLength": 10592,
+      "encodedDataLength": 76308
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.208",
+      "timestamp": 47321.85717,
+      "dataLength": 65536,
+      "encodedDataLength": 68814
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.208",
+      "timestamp": 47321.858114,
+      "dataLength": 3125,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.208",
+      "timestamp": 47321.858126,
+      "encodedDataLength": 145929,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.208",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.208",
+      "wallTime": 1671216905.831,
+      "timestamp": 47321.430071115494
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.209",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is4-ssl.mzstatic.com/image/thumb/P-HquLNfkzU1g_Wx0-eZUA/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.178738,
+      "wallTime": 1671216905.579578,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.209",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.807802,
+      "type": "Image",
+      "response": {
+        "url": "https://is4-ssl.mzstatic.com/image/thumb/P-HquLNfkzU1g_Wx0-eZUA/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "WNEYYJESMLEKETBDGVVF2FOK6E",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "b3498c249262c8a24c23356a5d15caf1",
+          "x-daiquiri-instance": "daiquiri:43624002:st44p00it-hyhk15014701:7987:22RELEASE175:daiquiri-amp-processing-shared-int-001-st",
+          "cdnuuid": "85e468cb-0027-4652-83f5-eb166f6fba36-198184469",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "b3498c249262c8a24c23356a5d15caf1-329bde75ac36dc42",
+          "content-length": "93775",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Tue, 13 Dec 2022 19:50:46 GMT",
+          "etag": "\"MSwxLjMuMS0yMlAsVmVyc2lvbiAxMi4xIChCdWlsZCAyMUM1MiksMTY3MDk2MTA0NjYzNCxpc0J1aWxkVmVyc2lvbk5vdFNldCw3MDM4NSxub0VmZmVjdA==\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "b3498c24-9262-c8a2-4c23-356a5d15caf1",
+          "x-b3-spanid": "329bde75ac36dc42",
+          "cache-control": "no-transform, max-age=15461754",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": false,
+        "connectionId": 231,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 806,
+        "timing": {
+          "requestTime": 47321.708846,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.18,
+          "dnsEnd": 24.973,
+          "connectStart": 24.973,
+          "connectEnd": 76.149,
+          "sslStart": 40.852,
+          "sslEnd": 76.145,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 76.229,
+          "sendEnd": 76.29,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 98.48
+        },
+        "responseTime": 1671216906208.103,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.209",
+      "timestamp": 47321.811459,
+      "dataLength": 16063,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.209",
+      "timestamp": 47321.820995,
+      "dataLength": 5629,
+      "encodedDataLength": 16108
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.209",
+      "timestamp": 47321.823446,
+      "dataLength": 5620,
+      "encodedDataLength": 5638
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.209",
+      "timestamp": 47321.831546,
+      "dataLength": 29929,
+      "encodedDataLength": 5638
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.209",
+      "timestamp": 47321.839893,
+      "dataLength": 36534,
+      "encodedDataLength": 29992
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.209",
+      "timestamp": 47321.840115,
+      "dataLength": 0,
+      "encodedDataLength": 36624
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.209",
+      "timestamp": 47321.839889,
+      "encodedDataLength": 94806,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.209",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.209",
+      "wallTime": 1671216905.831,
+      "timestamp": 47321.430071115494
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.210",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is1-ssl.mzstatic.com/image/thumb/gkWjLqLfF8Pahc6a6Udtxg/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.178839,
+      "wallTime": 1671216905.579678,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.210",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.831471,
+      "type": "Image",
+      "response": {
+        "url": "https://is1-ssl.mzstatic.com/image/thumb/gkWjLqLfF8Pahc6a6Udtxg/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "3S3CC7ECSPLZAPGPTXSJB25EDY",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "dcb6217c8293d7903ccf9de490eba41e",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE175:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "85e468cb-0027-4652-83f5-eb166f6fba36-17201806",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "dcb6217c8293d7903ccf9de490eba41e-fb9dd7faa7a4e5af",
+          "content-length": "154727",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Mon, 12 Dec 2022 21:30:02 GMT",
+          "etag": "\"MSwxLjMuMS0yMlAsVmVyc2lvbiAxMi4xIChCdWlsZCAyMUM1MiksMTY3MDg4MDYwMjk2Mixpc0J1aWxkVmVyc2lvbk5vdFNldCw2MDIyMSxub0VmZmVjdA==\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "dcb6217c-8293-d790-3ccf-9de490eba41e",
+          "x-b3-spanid": "fb9dd7faa7a4e5af",
+          "cache-control": "no-transform, max-age=15315640",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 806,
+        "timing": {
+          "requestTime": 47321.754272,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 42.537,
+          "sendEnd": 42.6,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 76.612
+        },
+        "responseTime": 1671216906231.672,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.210",
+      "timestamp": 47321.857483,
+      "dataLength": 65536,
+      "encodedDataLength": 79647
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.210",
+      "timestamp": 47321.85853,
+      "dataLength": 13922,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.210",
+      "timestamp": 47321.858538,
+      "dataLength": 24381,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.210",
+      "timestamp": 47321.860553,
+      "dataLength": 50888,
+      "encodedDataLength": 24426
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.210",
+      "timestamp": 47321.860652,
+      "dataLength": 0,
+      "encodedDataLength": 51014
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.210",
+      "timestamp": 47321.860506,
+      "encodedDataLength": 155893,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.210",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.210",
+      "wallTime": 1671216905.831,
+      "timestamp": 47321.430071115494
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.211",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/CXnyehPcDHEauavhg0D79Q/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.178939,
+      "wallTime": 1671216905.579778,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.211",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.82373,
+      "type": "Image",
+      "response": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/CXnyehPcDHEauavhg0D79Q/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "OCUC7J3DB3AKLXYTD4WUVORQWU",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "70a82fa7630ec0a5df131f2d4aba30b5",
+          "x-daiquiri-instance": "daiquiri:43624002:st44p00it-hyhk15014701:7987:22RELEASE133:daiquiri-amp-processing-shared-int-001-st",
+          "cdnuuid": "67ee4fbb-d8ef-4b80-b7d6-6ec2a1eae029-2076014961",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "70a82fa7630ec0a5df131f2d4aba30b5-95a6381e78681ba4",
+          "content-length": "111622",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Mon, 10 Oct 2022 17:00:26 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY1NDIxMjI2ODg2LGlzQnVpbGRWZXJzaW9uTm90U2V0LDcwNDM0LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "70a82fa7-630e-c0a5-df13-1f2d4aba30b5",
+          "x-b3-spanid": "95a6381e78681ba4",
+          "cache-control": "no-transform, max-age=11309339",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 806,
+        "timing": {
+          "requestTime": 47321.754322,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 24.741,
+          "sendEnd": 24.833,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 68.887
+        },
+        "responseTime": 1671216906223.978,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.211",
+      "timestamp": 47321.842893,
+      "dataLength": 29036,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.211",
+      "timestamp": 47321.847246,
+      "dataLength": 65536,
+      "encodedDataLength": 29108
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.211",
+      "timestamp": 47321.856222,
+      "dataLength": 17050,
+      "encodedDataLength": 74604
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.211",
+      "timestamp": 47321.856464,
+      "dataLength": 0,
+      "encodedDataLength": 8171
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.211",
+      "timestamp": 47321.856273,
+      "encodedDataLength": 112689,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.211",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.211",
+      "wallTime": 1671216905.831,
+      "timestamp": 47321.430071115494
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.212",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/EuF6BWsgBeic_Ap2qeAGBQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.179036,
+      "wallTime": 1671216905.579875,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.212",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.825877,
+      "type": "Image",
+      "response": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/EuF6BWsgBeic_Ap2qeAGBQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "R2XVRDZVOTDJIARMNOQLKRDSGI",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "8eaf588f3574c694022c6ba0b5447232",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE148:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "702e0c1f-ed84-4427-b61a-e8d0ec18c08b-394237496",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "8eaf588f3574c694022c6ba0b5447232-428bfc6bb7b28c6e",
+          "content-length": "140803",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Wed, 23 Nov 2022 01:58:58 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY5MTY4NzM4MDgzLGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMDk2LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "8eaf588f-3574-c694-022c-6ba0b5447232",
+          "x-b3-spanid": "428bfc6bb7b28c6e",
+          "cache-control": "no-transform, max-age=14830970",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 809,
+        "timing": {
+          "requestTime": 47321.75434,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 24.754,
+          "sendEnd": 24.816,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 71.116
+        },
+        "responseTime": 1671216906226.242,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.212",
+      "timestamp": 47321.85011,
+      "dataLength": 34931,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.212",
+      "timestamp": 47321.856497,
+      "dataLength": 105872,
+      "encodedDataLength": 35012
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.212",
+      "timestamp": 47321.856693,
+      "dataLength": 0,
+      "encodedDataLength": 106115
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.212",
+      "timestamp": 47321.856495,
+      "encodedDataLength": 141936,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.212",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.212",
+      "wallTime": 1671216905.831,
+      "timestamp": 47321.430071115494
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.213",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is5-ssl.mzstatic.com/image/thumb/7SeRlnCzKlgeqrg6-ixkig/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.179135,
+      "wallTime": 1671216905.579974,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.213",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.782757,
+      "type": "Image",
+      "response": {
+        "url": "https://is5-ssl.mzstatic.com/image/thumb/7SeRlnCzKlgeqrg6-ixkig/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "ZS6I5SB6Y4NOIZHPROBQM4KZV4",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "ccbc8ec83ec71ae464ef8b83067159af",
+          "x-daiquiri-instance": "daiquiri:43624002:st44p00it-hyhk15014701:7987:22RELEASE113:daiquiri-amp-processing-shared-int-001-st",
+          "cdnuuid": "df5ec70d-4d9f-4d3b-be4a-efc204e04128-3665563834",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "ccbc8ec83ec71ae464ef8b83067159af-5709db562dfacd8b",
+          "content-length": "157456",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Wed, 14 Sep 2022 14:03:21 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjYzMTY0MjAxNjkyLGlzQnVpbGRWZXJzaW9uTm90U2V0LDcwMzgxLG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "ccbc8ec8-3ec7-1ae4-64ef-8b83067159af",
+          "x-b3-spanid": "5709db562dfacd8b",
+          "cache-control": "no-transform, max-age=13609318",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 809,
+        "timing": {
+          "requestTime": 47321.754357,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 10.542,
+          "sendEnd": 10.609,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 27.723
+        },
+        "responseTime": 1671216906182.848,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.213",
+      "timestamp": 47321.783463,
+      "dataLength": 1992,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.213",
+      "timestamp": 47321.79158,
+      "dataLength": 14068,
+      "encodedDataLength": 2010
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.213",
+      "timestamp": 47321.79655,
+      "dataLength": 4996,
+      "encodedDataLength": 14095
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.213",
+      "timestamp": 47321.833626,
+      "dataLength": 65536,
+      "encodedDataLength": 5005
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.213",
+      "timestamp": 47321.838232,
+      "dataLength": 48840,
+      "encodedDataLength": 68416
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.213",
+      "timestamp": 47321.842552,
+      "dataLength": 22024,
+      "encodedDataLength": 46221
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.213",
+      "timestamp": 47321.842854,
+      "dataLength": 0,
+      "encodedDataLength": 22078
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.213",
+      "timestamp": 47321.842548,
+      "encodedDataLength": 158634,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.213",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.213",
+      "wallTime": 1671216905.832,
+      "timestamp": 47321.431071043015
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.214",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/78-I7VenST4ztZYfwMf6AQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.179235,
+      "wallTime": 1671216905.580073,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.214",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.810939,
+      "type": "Image",
+      "response": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/78-I7VenST4ztZYfwMf6AQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "HW3EMAZLBBNEVBM42NXGC5JTAE",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "3db646032b085a4a859cd36e61753301",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE91:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "96ac4f6b-254e-4c43-818a-d41d3950b824-5944867109",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "3db646032b085a4a859cd36e61753301-15329ea29c5336aa",
+          "content-length": "100601",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Thu, 28 Jul 2022 03:01:53 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjU4OTc3MzEzMjk4LGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMzEwLG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "3db64603-2b08-5a4a-859c-d36e61753301",
+          "x-b3-spanid": "15329ea29c5336aa",
+          "cache-control": "no-transform, max-age=14054802",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 206,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 807,
+        "timing": {
+          "requestTime": 47321.754374,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 12.606,
+          "sendEnd": 12.672,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 56.059
+        },
+        "responseTime": 1671216906211.203,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.214",
+      "timestamp": 47321.853957,
+      "dataLength": 61929,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.214",
+      "timestamp": 47321.880188,
+      "dataLength": 38672,
+      "encodedDataLength": 62073
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.214",
+      "timestamp": 47321.880296,
+      "dataLength": 0,
+      "encodedDataLength": 38771
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.214",
+      "timestamp": 47321.880151,
+      "encodedDataLength": 101651,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.214",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.214",
+      "wallTime": 1671216905.832,
+      "timestamp": 47321.431071043015
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.215",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/AWDRdQz0nepFpnsUNiTDuw/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47321.179341,
+      "wallTime": 1671216905.580179,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.215",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.859671,
+      "type": "Image",
+      "response": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/AWDRdQz0nepFpnsUNiTDuw/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "POYHAAZJN42U5CSIXRPRSRK25Y",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "7bb07003296f354e8a48bc5f19455aee",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22HOTFIX7:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "5feeff8f-85f9-46d9-a18d-4f0e37d30fb3-3333223677",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "7bb07003296f354e8a48bc5f19455aee-87f59c9448d6e386",
+          "content-length": "130884",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Sat, 24 Sep 2022 08:23:50 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY0MDA3ODMwNTMwLGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMDQ0LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "7bb07003-296f-354e-8a48-bc5f19455aee",
+          "x-b3-spanid": "87f59c9448d6e386",
+          "cache-control": "no-transform, max-age=13611133",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 809,
+        "timing": {
+          "requestTime": 47321.826423,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.166,
+          "sendEnd": 0.202,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 32.721
+        },
+        "responseTime": 1671216906259.915,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.215",
+      "timestamp": 47321.862608,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.215",
+      "timestamp": 47321.863345,
+      "dataLength": 12463,
+      "encodedDataLength": 78188
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.215",
+      "timestamp": 47321.864161,
+      "dataLength": 52885,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.215",
+      "timestamp": 47321.864252,
+      "dataLength": 0,
+      "encodedDataLength": 53002
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.215",
+      "timestamp": 47321.864138,
+      "encodedDataLength": 131999,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.215",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.215",
+      "wallTime": 1671216905.832,
+      "timestamp": 47321.431071043015
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.128",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_bold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.179656,
+      "wallTime": 1671216905.580498,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.128",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.23415,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_bold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:55:05 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=2482",
+          "content-length": "232592",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:36:28 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 719,
+        "timing": {
+          "requestTime": 47322.188792,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.12,
+          "sendEnd": 0.184,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.878
+        },
+        "responseTime": 1671216906634.462,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.128",
+      "timestamp": 47322.234761,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.128",
+      "timestamp": 47322.240922,
+      "dataLength": 79760,
+      "encodedDataLength": 79940
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.128",
+      "timestamp": 47322.248205,
+      "dataLength": 87296,
+      "encodedDataLength": 153183
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.128",
+      "timestamp": 47322.242259,
+      "encodedDataLength": 233842,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.128",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.128",
+      "wallTime": 1671216906.337,
+      "timestamp": 47321.93607091904
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.164",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Icons/v3/sf-pro-icons_bold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.179714,
+      "wallTime": 1671216905.580554,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.164",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.237498,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Icons/v3/sf-pro-icons_bold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:50 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=515",
+          "content-length": "11756",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:03:41 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 720,
+        "timing": {
+          "requestTime": 47322.189544,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.059,
+          "sendEnd": 0.108,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 47.331
+        },
+        "responseTime": 1671216906637.644,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.164",
+      "timestamp": 47322.237519,
+      "dataLength": 11756,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.164",
+      "timestamp": 47322.238086,
+      "dataLength": 0,
+      "encodedDataLength": 11801
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.164",
+      "timestamp": 47322.237087,
+      "encodedDataLength": 12521,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.164",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.164",
+      "wallTime": 1671216906.337,
+      "timestamp": 47321.93607091904
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.74",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_bold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47321.179756,
+      "wallTime": 1671216905.580596,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.74",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.230455,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_bold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:46 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=2075",
+          "content-length": "229396",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:29:41 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 719,
+        "timing": {
+          "requestTime": 47322.189746,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.054,
+          "sendEnd": 0.086,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 40.194
+        },
+        "responseTime": 1671216906630.711,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.74",
+      "timestamp": 47322.230948,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.74",
+      "timestamp": 47322.240997,
+      "dataLength": 81012,
+      "encodedDataLength": 81201
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.74",
+      "timestamp": 47322.241994,
+      "dataLength": 82848,
+      "encodedDataLength": 148717
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.74",
+      "timestamp": 47322.241995,
+      "encodedDataLength": 230637,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.74",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.74",
+      "wallTime": 1671216906.337,
+      "timestamp": 47321.93607091904
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.216",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://securemetrics.apple.com/b/ss/applestoreww/1/JS-2.22.0/s2613455921701?AQB=1&ndh=1&pf=1&t=16%2F11%2F2022%2011%3A55%3A5%205%20420&fid=494188FEBF2F6DB0-240F3FCD19EA1195&ce=UTF-8&cdp=2&cl=1800&pageName=apple%20-%20index%2Ftab%20%28us%29&g=https%3A%2F%2Fwww.apple.com%2F&cc=USD&ch=www.us.homepage&server=ac-2.16.0&h1=www.us.homepage&v3=aos%3A%20us&l3=D%3Das_tex&c4=D%3Dg&v4=D%3DpageName&v14=en-us&c20=aos%3A%20us&v54=D%3Dg&v97=s.t-p&s=1728x1117&c=30&j=1.6&v=N&k=Y&bw=1366&bh=768&AQE=1",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.196623,
+      "wallTime": 1671216905.597493,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [],
+          "parent": {
+            "description": "Image",
+            "callFrames": [
+              {
+                "functionName": "t.$b",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 119933
+              },
+              {
+                "functionName": "t.U",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 117901
+              },
+              {
+                "functionName": "t.sb",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 115397
+              },
+              {
+                "functionName": "t.Fa",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 113244
+              },
+              {
+                "functionName": "t.t.t.track",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 113432
+              },
+              {
+                "functionName": "submit",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 197094
+              },
+              {
+                "functionName": "value",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 150358
+              },
+              {
+                "functionName": "value",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 205228
+              },
+              {
+                "functionName": "",
+                "scriptId": "18",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 205670
+              }
+            ],
+            "parent": {
+              "description": "setTimeout",
+              "callFrames": [
+                {
+                  "functionName": "",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 205648
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 205624
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 204853
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 204484
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 266732
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 265488
+                },
+                {
+                  "functionName": "r",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 265131
+                },
+                {
+                  "functionName": "onPageDataLoaded",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 232758
+                },
+                {
+                  "functionName": "initialize",
+                  "scriptId": "18",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 232522
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "11",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 31089
+                },
+                {
+                  "functionName": "e.exports",
+                  "scriptId": "11",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 31117
+                },
+                {
+                  "functionName": "190.191",
+                  "scriptId": "11",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 225455
+                },
+                {
+                  "functionName": "r",
+                  "scriptId": "11",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 253
+                },
+                {
+                  "functionName": "t",
+                  "scriptId": "11",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 413
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "11",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 430
+                }
+              ]
+            }
+          }
+        }
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.216",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://securemetrics.apple.com/b/ss/applestoreww/1/JS-2.22.0/s2613455921701?AQB=1&pccr=true&vidn=31CE5F855982D2C1-400003C2BC0CF8C1&ndh=1&pf=1&t=16%2F11%2F2022%2011%3A55%3A5%205%20420&fid=494188FEBF2F6DB0-240F3FCD19EA1195&ce=UTF-8&cdp=2&cl=1800&pageName=apple%20-%20index%2Ftab%20%28us%29&g=https%3A%2F%2Fwww.apple.com%2F&cc=USD&ch=www.us.homepage&server=ac-2.16.0&h1=www.us.homepage&v3=aos%3A%20us&l3=D%3Das_tex&c4=D%3Dg&v4=D%3DpageName&v14=en-us&c20=aos%3A%20us&v54=D%3Dg&v97=s.t-p&s=1728x1117&c=30&j=1.6&v=N&k=Y&bw=1366&bh=768&AQE=1",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47322.153436,
+      "wallTime": 1671216906.554316,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": true,
+      "redirectResponse": {
+        "url": "https://securemetrics.apple.com/b/ss/applestoreww/1/JS-2.22.0/s2613455921701?AQB=1&ndh=1&pf=1&t=16%2F11%2F2022%2011%3A55%3A5%205%20420&fid=494188FEBF2F6DB0-240F3FCD19EA1195&ce=UTF-8&cdp=2&cl=1800&pageName=apple%20-%20index%2Ftab%20%28us%29&g=https%3A%2F%2Fwww.apple.com%2F&cc=USD&ch=www.us.homepage&server=ac-2.16.0&h1=www.us.homepage&v3=aos%3A%20us&l3=D%3Das_tex&c4=D%3Dg&v4=D%3DpageName&v14=en-us&c20=aos%3A%20us&v54=D%3Dg&v97=s.t-p&s=1728x1117&c=30&j=1.6&v=N&k=Y&bw=1366&bh=768&AQE=1",
+        "status": 302,
+        "statusText": "",
+        "headers": {
+          "pragma": "no-cache",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "x-content-type-options": "nosniff",
+          "last-modified": "Sat, 17 Dec 2022 18:55:06 GMT",
+          "server": "jag",
+          "vary": "Origin",
+          "p3p": "CP=\"This is not a P3P policy\"",
+          "access-control-allow-origin": "*",
+          "location": "https://securemetrics.apple.com/b/ss/applestoreww/1/JS-2.22.0/s2613455921701?AQB=1&pccr=true&vidn=31CE5F855982D2C1-400003C2BC0CF8C1&ndh=1&pf=1&t=16%2F11%2F2022%2011%3A55%3A5%205%20420&fid=494188FEBF2F6DB0-240F3FCD19EA1195&ce=UTF-8&cdp=2&cl=1800&pageName=apple%20-%20index%2Ftab%20%28us%29&g=https%3A%2F%2Fwww.apple.com%2F&cc=USD&ch=www.us.homepage&server=ac-2.16.0&h1=www.us.homepage&v3=aos%3A%20us&l3=D%3Das_tex&c4=D%3Dg&v4=D%3DpageName&v14=en-us&c20=aos%3A%20us&v54=D%3Dg&v97=s.t-p&s=1728x1117&c=30&j=1.6&v=N&k=Y&bw=1366&bh=768&AQE=1",
+          "content-type": "text/plain;charset=utf-8",
+          "cache-control": "no-cache, no-store, max-age=0, no-transform, private",
+          "content-length": "0",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Thu, 15 Dec 2022 18:55:06 GMT"
+        },
+        "mimeType": "text/plain",
+        "connectionReused": false,
+        "connectionId": 279,
+        "remoteIPAddress": "63.140.36.121",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 808,
+        "timing": {
+          "requestTime": 47321.830593,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.195,
+          "dnsEnd": 22.532,
+          "connectStart": 22.532,
+          "connectEnd": 269.014,
+          "sslStart": 64.471,
+          "sslEnd": 269.011,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 269.074,
+          "sendEnd": 269.115,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 314.674
+        },
+        "responseTime": 1671216906546.042,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "securemetrics.apple.com",
+          "sanList": [
+            "securemetrics.apple.com",
+            "securemvt.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1651689708,
+          "validTo": 1685817707,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.216",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.703467,
+      "type": "Image",
+      "response": {
+        "url": "https://securemetrics.apple.com/b/ss/applestoreww/1/JS-2.22.0/s2613455921701?AQB=1&pccr=true&vidn=31CE5F855982D2C1-400003C2BC0CF8C1&ndh=1&pf=1&t=16%2F11%2F2022%2011%3A55%3A5%205%20420&fid=494188FEBF2F6DB0-240F3FCD19EA1195&ce=UTF-8&cdp=2&cl=1800&pageName=apple%20-%20index%2Ftab%20%28us%29&g=https%3A%2F%2Fwww.apple.com%2F&cc=USD&ch=www.us.homepage&server=ac-2.16.0&h1=www.us.homepage&v3=aos%3A%20us&l3=D%3Das_tex&c4=D%3Dg&v4=D%3DpageName&v14=en-us&c20=aos%3A%20us&v54=D%3Dg&v97=s.t-p&s=1728x1117&c=30&j=1.6&v=N&k=Y&bw=1366&bh=768&AQE=1",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "pragma": "no-cache",
+          "date": "Fri, 16 Dec 2022 18:55:07 GMT",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "x-content-type-options": "nosniff",
+          "last-modified": "Sat, 17 Dec 2022 18:55:07 GMT",
+          "server": "jag",
+          "etag": "3588910981609652224-4619322003136264070",
+          "vary": "*",
+          "p3p": "CP=\"This is not a P3P policy\"",
+          "access-control-allow-origin": "*",
+          "content-type": "image/gif;charset=utf-8",
+          "cache-control": "no-cache, no-store, max-age=0, no-transform, private",
+          "content-length": "43",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Thu, 15 Dec 2022 18:55:07 GMT"
+        },
+        "mimeType": "image/gif",
+        "connectionReused": true,
+        "connectionId": 279,
+        "remoteIPAddress": "63.140.36.121",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 268,
+        "timing": {
+          "requestTime": 47322.65751,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.185,
+          "sendEnd": 0.295,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.88
+        },
+        "responseTime": 1671216907103.144,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "unknown"
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.216",
+      "timestamp": 47322.703522,
+      "dataLength": 43,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.216",
+      "timestamp": 47322.703697,
+      "dataLength": 0,
+      "encodedDataLength": 61
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.216",
+      "timestamp": 47322.702702,
+      "encodedDataLength": 329,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.216",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.216",
+      "wallTime": 1671216906.805,
+      "timestamp": 47322.404071092606
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.217",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/search-services/suggestions/defaultlinks/?src=globalnav&locale=en_US",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.201595,
+      "wallTime": 1671216905.602473,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "n.send",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 21264
+            },
+            {
+              "functionName": "ajax",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 20548
+            },
+            {
+              "functionName": "get",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 20606
+            },
+            {
+              "functionName": "h.fetchData",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 92069
+            },
+            {
+              "functionName": "u.fetchData",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 84957
+            },
+            {
+              "functionName": "v.fetchData",
+              "scriptId": "15",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 77396
+            }
+          ]
+        }
+      },
+      "redirectHasExtraInfo": false,
+      "type": "XHR",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.217",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.75877,
+      "type": "XHR",
+      "response": {
+        "url": "https://www.apple.com/search-services/suggestions/defaultlinks/?src=globalnav&locale=en_US",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "x-content-type-options": "nosniff",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "application/json",
+          "cache-control": "max-age=272",
+          "content-length": "526",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:59:38 GMT"
+        },
+        "mimeType": "application/json",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 720,
+        "timing": {
+          "requestTime": 47321.704642,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.085,
+          "sendEnd": 0.14,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 53.69
+        },
+        "responseTime": 1671216906159.13,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.217",
+      "timestamp": 47321.758793,
+      "dataLength": 526,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.217",
+      "timestamp": 47321.760384,
+      "dataLength": 0,
+      "encodedDataLength": 544
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.217",
+      "timestamp": 47321.758565,
+      "encodedDataLength": 1264,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.217",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.217",
+      "wallTime": 1671216905.854,
+      "timestamp": 47321.4530711174
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.218",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/105/media/us/home/2022/85449b20-a1fc-4234-ab63-32e595b20f2a/anim/memoji-2/large_2x.mp4",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "Accept-Encoding": "identity;q=1, *;q=0",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint",
+          "Range": "bytes=0-"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.204035,
+      "wallTime": 1671216905.604884,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Media",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.218",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.886103,
+      "type": "Media",
+      "response": {
+        "url": "https://www.apple.com/105/media/us/home/2022/85449b20-a1fc-4234-ab63-32e595b20f2a/anim/memoji-2/large_2x.mp4",
+        "status": 206,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "Content-Range": "bytes 0-4996752/4996753",
+          "Content-Length": "4996753",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 04 Nov 2022 14:47:39 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "video/mp4",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Range, Content-Length, Accept-Ranges",
+          "cache-control": "max-age=328",
+          "accept-ranges": "bytes",
+          "access-control-allow-headers": "Range",
+          "expires": "Fri, 16 Dec 2022 19:00:34 GMT"
+        },
+        "mimeType": "video/mp4",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 854,
+        "timing": {
+          "requestTime": 47321.83067,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.348,
+          "sendEnd": 0.458,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 55.041
+        },
+        "responseTime": 1671216906286.425,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.88801,
+      "dataLength": 13751,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.888032,
+      "dataLength": 21282,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.890512,
+      "dataLength": 28504,
+      "encodedDataLength": 35114
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.891834,
+      "dataLength": 16339,
+      "encodedDataLength": 28567
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.896903,
+      "dataLength": 65152,
+      "encodedDataLength": 16384
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.900248,
+      "dataLength": 24381,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.90112,
+      "dataLength": 24432,
+      "encodedDataLength": 89722
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.915826,
+      "dataLength": 16339,
+      "encodedDataLength": 24486
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.919065,
+      "dataLength": 48813,
+      "encodedDataLength": 16384
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.919143,
+      "dataLength": 16339,
+      "encodedDataLength": 65296
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.961879,
+      "dataLength": 667868,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFailed",
+    "params": {
+      "requestId": "14040.218",
+      "timestamp": 47321.995582,
+      "type": "Media",
+      "errorText": "net::ERR_ABORTED",
+      "canceled": true
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.218",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.218",
+      "wallTime": 1671216905.856,
+      "timestamp": 47321.45507097244
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.219",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/iphone-14/hero_iphone14__fjmsqstr1ceq_large.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.207686,
+      "wallTime": 1671216905.608532,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.219",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.753541,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/iphone-14/hero_iphone14__fjmsqstr1ceq_large.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:52 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/jpeg",
+          "cache-control": "max-age=3339",
+          "accept-ranges": "bytes",
+          "content-length": "62668",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:50:45 GMT"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 751,
+        "timing": {
+          "requestTime": 47321.709656,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.053,
+          "sendEnd": 0.093,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 43.478
+        },
+        "responseTime": 1671216906153.934,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.219",
+      "timestamp": 47321.7543,
+      "dataLength": 8058,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.219",
+      "timestamp": 47321.767386,
+      "dataLength": 16348,
+      "encodedDataLength": 8085
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.219",
+      "timestamp": 47321.76743,
+      "dataLength": 38262,
+      "encodedDataLength": 54754
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.219",
+      "timestamp": 47321.767395,
+      "encodedDataLength": 63590,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.219",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.219",
+      "wallTime": 1671216905.86,
+      "timestamp": 47321.459070920944
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.220",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/holiday-2022/memoji02/hero_startframe__dbi4flqyio2u_large.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.207842,
+      "wallTime": 1671216905.608681,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.220",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.75144,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/holiday-2022/memoji02/hero_startframe__dbi4flqyio2u_large.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:52 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/jpeg",
+          "cache-control": "max-age=1071",
+          "accept-ranges": "bytes",
+          "content-length": "23109",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:12:57 GMT"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 751,
+        "timing": {
+          "requestTime": 47321.709878,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.039,
+          "sendEnd": 0.071,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 41.034
+        },
+        "responseTime": 1671216906151.678,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.220",
+      "timestamp": 47321.752293,
+      "dataLength": 15588,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.220",
+      "timestamp": 47321.765262,
+      "dataLength": 7521,
+      "encodedDataLength": 15633
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.220",
+      "timestamp": 47321.765483,
+      "dataLength": 0,
+      "encodedDataLength": 7548
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.220",
+      "timestamp": 47321.765236,
+      "encodedDataLength": 23932,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.220",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.220",
+      "wallTime": 1671216905.86,
+      "timestamp": 47321.459070920944
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.221",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/holiday-2022/hero_endframe__8xosbwdvpaqe_large.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.20791,
+      "wallTime": 1671216905.608748,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.221",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.760555,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/holiday-2022/hero_endframe__8xosbwdvpaqe_large.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:52 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/jpeg",
+          "cache-control": "max-age=1959",
+          "accept-ranges": "bytes",
+          "content-length": "36182",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:27:45 GMT"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 751,
+        "timing": {
+          "requestTime": 47321.711458,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.046,
+          "sendEnd": 0.076,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.996
+        },
+        "responseTime": 1671216906159.257,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.221",
+      "timestamp": 47321.760569,
+      "dataLength": 36182,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.221",
+      "timestamp": 47321.760674,
+      "dataLength": 0,
+      "encodedDataLength": 36290
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.221",
+      "timestamp": 47321.760121,
+      "encodedDataLength": 37041,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.221",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.221",
+      "wallTime": 1671216905.86,
+      "timestamp": 47321.459070920944
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.222",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/apple-card-december/hero__dvsxv8smkkgi_large.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.207976,
+      "wallTime": 1671216905.608815,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.222",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47321.874073,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/apple-card-december/hero__dvsxv8smkkgi_large.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:51 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/jpeg",
+          "cache-control": "max-age=1551",
+          "accept-ranges": "bytes",
+          "content-length": "164456",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:20:57 GMT"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 749,
+        "timing": {
+          "requestTime": 47321.830699,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.375,
+          "sendEnd": 0.431,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 42.907
+        },
+        "responseTime": 1671216906274.387,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.222",
+      "timestamp": 47321.875988,
+      "dataLength": 31938,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.222",
+      "timestamp": 47321.878003,
+      "dataLength": 32696,
+      "encodedDataLength": 32019
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.222",
+      "timestamp": 47321.879585,
+      "dataLength": 16348,
+      "encodedDataLength": 32768
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.222",
+      "timestamp": 47321.882802,
+      "dataLength": 49044,
+      "encodedDataLength": 16384
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.222",
+      "timestamp": 47321.884381,
+      "dataLength": 16348,
+      "encodedDataLength": 49152
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.222",
+      "timestamp": 47321.885539,
+      "dataLength": 18082,
+      "encodedDataLength": 16384
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.222",
+      "timestamp": 47321.885688,
+      "dataLength": 0,
+      "encodedDataLength": 18127
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.222",
+      "timestamp": 47321.885542,
+      "encodedDataLength": 165583,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.222",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.222",
+      "wallTime": 1671216905.861,
+      "timestamp": 47321.46007108688
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.223",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/105/media/us/home/2022/85449b20-a1fc-4234-ab63-32e595b20f2a/anim/memoji-2/large_2x.mp4",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "Accept-Encoding": "identity;q=1, *;q=0",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint",
+          "Range": "bytes=917504-"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47321.999215,
+      "wallTime": 1671216906.400072,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Media",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.223",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47322.514197,
+      "type": "Media",
+      "response": {
+        "url": "https://www.apple.com/105/media/us/home/2022/85449b20-a1fc-4234-ab63-32e595b20f2a/anim/memoji-2/large_2x.mp4",
+        "status": 206,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-content-type-options": "nosniff",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "Content-Range": "bytes 917504-4996752/4996753",
+          "Content-Length": "4079249",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 04 Nov 2022 14:47:39 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "video/mp4",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Range, Content-Length, Accept-Ranges",
+          "cache-control": "max-age=328",
+          "accept-ranges": "bytes",
+          "access-control-allow-headers": "Range",
+          "expires": "Fri, 16 Dec 2022 19:00:34 GMT"
+        },
+        "mimeType": "video/mp4",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47322.501827,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.054,
+          "sendEnd": 0.054,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 11.848
+        },
+        "responseTime": 1671216906286.425,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.223",
+      "timestamp": 47322.514418,
+      "dataLength": 655360,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFailed",
+    "params": {
+      "requestId": "14040.223",
+      "timestamp": 47322.514641,
+      "type": "Media",
+      "errorText": "net::ERR_ABORTED",
+      "canceled": true
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.223",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.223",
+      "wallTime": 1671216906.65,
+      "timestamp": 47322.249071121216
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.224",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/105/media/us/home/2022/85449b20-a1fc-4234-ab63-32e595b20f2a/anim/memoji-2/large_2x.mp4",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "Accept-Encoding": "identity;q=1, *;q=0",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint",
+          "Range": "bytes=1572864-"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47322.515416,
+      "wallTime": 1671216906.916273,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Media",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.224",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47323.028121,
+      "type": "Media",
+      "response": {
+        "url": "https://www.apple.com/105/media/us/home/2022/85449b20-a1fc-4234-ab63-32e595b20f2a/anim/memoji-2/large_2x.mp4",
+        "status": 206,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-content-type-options": "nosniff",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "Content-Range": "bytes 1572864-4996752/4996753",
+          "Content-Length": "3423889",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 04 Nov 2022 14:47:39 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "video/mp4",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Range, Content-Length, Accept-Ranges",
+          "cache-control": "max-age=328",
+          "accept-ranges": "bytes",
+          "access-control-allow-headers": "Range",
+          "expires": "Fri, 16 Dec 2022 19:00:34 GMT"
+        },
+        "mimeType": "video/mp4",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47323.023278,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.156,
+          "sendEnd": 0.156,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 3.858
+        },
+        "responseTime": 1671216906286.425,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.224",
+      "timestamp": 47323.028257,
+      "dataLength": 200964,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFailed",
+    "params": {
+      "requestId": "14040.224",
+      "timestamp": 47323.028481,
+      "type": "Media",
+      "errorText": "net::ERR_ABORTED",
+      "canceled": true
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.224",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.224",
+      "wallTime": 1671216907.171,
+      "timestamp": 47322.77007102966
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.225",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/105/media/us/home/2022/85449b20-a1fc-4234-ab63-32e595b20f2a/anim/memoji-2/large_2x.mp4",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "Accept-Encoding": "identity;q=1, *;q=0",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint",
+          "Range": "bytes=1769472-"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47323.028652,
+      "wallTime": 1671216907.429508,
+      "initiator": {
+        "type": "other"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Media",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.225",
+      "loaderId": "EE2FA84EC18658CA0EF531EDF0401EA8",
+      "timestamp": 47323.544954,
+      "type": "Media",
+      "response": {
+        "url": "https://www.apple.com/105/media/us/home/2022/85449b20-a1fc-4234-ab63-32e595b20f2a/anim/memoji-2/large_2x.mp4",
+        "status": 206,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-content-type-options": "nosniff",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "Content-Range": "bytes 1769472-4996752/4996753",
+          "Content-Length": "3227281",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 04 Nov 2022 14:47:39 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "video/mp4",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Range, Content-Length, Accept-Ranges",
+          "cache-control": "max-age=328",
+          "accept-ranges": "bytes",
+          "access-control-allow-headers": "Range",
+          "expires": "Fri, 16 Dec 2022 19:00:34 GMT"
+        },
+        "mimeType": "video/mp4",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47323.540237,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.062,
+          "sendEnd": 0.062,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 3.586
+        },
+        "responseTime": 1671216906286.425,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.225",
+      "timestamp": 47323.545915,
+      "dataLength": 4356,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.225",
+      "timestamp": 47323.598533,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.225",
+      "timestamp": 47323.598571,
+      "dataLength": 15345,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.225",
+      "timestamp": 47323.598654,
+      "dataLength": 16348,
+      "encodedDataLength": 98304
+    }
+  },
+  {
+    "method": "Network.loadingFailed",
+    "params": {
+      "requestId": "14040.225",
+      "timestamp": 47323.598752,
+      "type": "Media",
+      "errorText": "net::ERR_ABORTED",
+      "canceled": true
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.225",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.225",
+      "wallTime": 1671216907.685,
+      "timestamp": 47323.28407096863
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.227",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.150489,
+      "wallTime": 1671216914.551337,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 100,
+        "columnNumber": 101
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.227",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.727028,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:15 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "ntcoent-length": "116297",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=0",
+          "content-length": "12667",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:15 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 720,
+        "timing": {
+          "requestTime": 47330.658931,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.219,
+          "sendEnd": 0.363,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 67.429
+        },
+        "responseTime": 1671216915127.089,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.227",
+      "timestamp": 47330.727057,
+      "dataLength": 116297,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.227",
+      "timestamp": 47330.728306,
+      "dataLength": 0,
+      "encodedDataLength": 12721
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.227",
+      "timestamp": 47330.726736,
+      "encodedDataLength": 13441,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.227",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.227",
+      "wallTime": 1671216914.802,
+      "timestamp": 47330.401071071625
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.228",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/localnav/6/styles/ac-localnav.built.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.150735,
+      "wallTime": 1671216914.551577,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 101,
+        "columnNumber": 93
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.228",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.674577,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/ac/localnav/6/styles/ac-localnav.built.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "content-encoding": "gzip",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "text/css",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "cache-control": "max-age=52",
+          "content-length": "7086",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:57 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47330.659672,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.042,
+          "sendEnd": 0.042,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 13.575
+        },
+        "responseTime": 1671216905423.135,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.228",
+      "timestamp": 47330.674639,
+      "dataLength": 80101,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.228",
+      "timestamp": 47330.673951,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.228",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.228",
+      "wallTime": 1671216914.803,
+      "timestamp": 47330.402070999146
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.229",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalfooter/7/en_US/styles/ac-globalfooter.built.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.150947,
+      "wallTime": 1671216914.551784,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 102,
+        "columnNumber": 107
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.229",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.717807,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/ac/globalfooter/7/en_US/styles/ac-globalfooter.built.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:15 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css",
+          "nncoection": "close",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=0",
+          "content-length": "5342",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:15 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 704,
+        "timing": {
+          "requestTime": 47330.660284,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.127,
+          "sendEnd": 0.214,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 56.803
+        },
+        "responseTime": 1671216915117.827,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.229",
+      "timestamp": 47330.717838,
+      "dataLength": 45448,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.229",
+      "timestamp": 47330.718662,
+      "dataLength": 0,
+      "encodedDataLength": 5378
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.229",
+      "timestamp": 47330.717376,
+      "encodedDataLength": 6082,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.229",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.229",
+      "wallTime": 1671216914.803,
+      "timestamp": 47330.402070999146
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.230",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.151085,
+      "wallTime": 1671216914.551911,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 157,
+        "columnNumber": 107
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.230",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.676735,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "cteonnt-length": "22124",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "content-encoding": "gzip",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "server": "Apple",
+          "etag": "3031aa1b654ca979f7577e4706173d35a9d8ff35cbdb80a8e4911fd9423e2bc4",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css;charset=UTF-8",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=2162",
+          "content-length": "1169",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:31:07 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47330.660791,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.035,
+          "sendEnd": 0.035,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 13.653
+        },
+        "responseTime": 1671216905406.688,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.230",
+      "timestamp": 47330.676761,
+      "dataLength": 22124,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.230",
+      "timestamp": 47330.67484,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.230",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.230",
+      "wallTime": 1671216914.804,
+      "timestamp": 47330.403070926666
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.231",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.151299,
+      "wallTime": 1671216914.552127,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 158,
+        "columnNumber": 88
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.231",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.677127,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "content-encoding": "gzip",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "44956",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 16 Dec 2022 00:11:20 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css",
+          "cache-control": "max-age=77",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:22 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47330.662141,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.036,
+          "sendEnd": 0.036,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 13.567
+        },
+        "responseTime": 1671216905253.876,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.231",
+      "timestamp": 47330.677156,
+      "dataLength": 839106,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.231",
+      "timestamp": 47330.676823,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.231",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.231",
+      "wallTime": 1671216914.804,
+      "timestamp": 47330.403070926666
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.232",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/built/scripts/head.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.151505,
+      "wallTime": 1671216914.552331,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 159,
+        "columnNumber": 93
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.232"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.232",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.151683,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/built/scripts/head.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "5548",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:51 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=77",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:22 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 6353,
+        "timing": {
+          "requestTime": 47320.610907,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.086,
+          "sendEnd": 0.136,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 274.598
+        },
+        "responseTime": 1671216905286.2,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.232",
+      "timestamp": 47330.151698,
+      "dataLength": 21142,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.232",
+      "timestamp": 47330.151702,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.232",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.233",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.151772,
+      "wallTime": 1671216914.552602,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 341,
+        "columnNumber": 89
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.233",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.720176,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:15 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "application/x-javascript",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=0",
+          "content-length": "26946",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:15 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 710,
+        "timing": {
+          "requestTime": 47330.662487,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.102,
+          "sendEnd": 0.181,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 57.016
+        },
+        "responseTime": 1671216915120.246,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.233",
+      "timestamp": 47330.720217,
+      "dataLength": 100956,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.233",
+      "timestamp": 47330.722177,
+      "dataLength": 0,
+      "encodedDataLength": 27036
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.233",
+      "timestamp": 47330.720076,
+      "encodedDataLength": 27746,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.233",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.233",
+      "wallTime": 1671216914.806,
+      "timestamp": 47330.405071020126
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.234",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.152002,
+      "wallTime": 1671216914.552829,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 345,
+        "columnNumber": 106
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.234"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.234",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.152134,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "x-content-type-options": "nosniff",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/x-javascript",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=10",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:15 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 78068,
+        "timing": {
+          "requestTime": 47320.612478,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.09,
+          "sendEnd": 0.365,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 457.49
+        },
+        "responseTime": 1671216905470.752,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.234",
+      "timestamp": 47330.152143,
+      "dataLength": 327242,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.234",
+      "timestamp": 47330.152145,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.234",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.235",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalfooter/7/en_US/scripts/ac-globalfooter.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.152193,
+      "wallTime": 1671216914.553015,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1397,
+        "columnNumber": 95
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.235",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.718947,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/ac/globalfooter/7/en_US/scripts/ac-globalfooter.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:15 GMT",
+          "content-encoding": "gzip",
+          "ntcoent-length": "6983",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "cneonction": "close",
+          "content-length": "2482",
+          "x-xss-protection": "1; mode=block",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=0",
+          "expires": "Fri, 16 Dec 2022 18:55:15 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 756,
+        "timing": {
+          "requestTime": 47330.663991,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.227,
+          "sendEnd": 0.612,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 53.577
+        },
+        "responseTime": 1671216915118.312,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.235",
+      "timestamp": 47330.71898,
+      "dataLength": 6983,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.235",
+      "timestamp": 47330.71931,
+      "dataLength": 0,
+      "encodedDataLength": 2509
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.235",
+      "timestamp": 47330.717762,
+      "encodedDataLength": 3265,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.235",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.235",
+      "wallTime": 1671216914.807,
+      "timestamp": 47330.40607094765
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.236",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.15246,
+      "wallTime": 1671216914.553307,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1444,
+        "columnNumber": 96
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.236"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.236",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.152708,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "cneonction": "close",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=162",
+          "expires": "Fri, 16 Dec 2022 18:57:47 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 57065,
+        "timing": {
+          "requestTime": 47320.616308,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.127,
+          "sendEnd": 0.475,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 432.951
+        },
+        "responseTime": 1671216905450.036,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.236",
+      "timestamp": 47330.152718,
+      "dataLength": 192491,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.236",
+      "timestamp": 47330.15272,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.236",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.237",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.152753,
+      "wallTime": 1671216914.553574,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1477,
+        "columnNumber": 93
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.237"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.237",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.152858,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "56738",
+          "x-xss-protection": "1; mode=block",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:51 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=332",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:00:37 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 57679,
+        "timing": {
+          "requestTime": 47320.61667,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.151,
+          "sendEnd": 0.216,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 289.125
+        },
+        "responseTime": 1671216905306.397,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.237",
+      "timestamp": 47330.152868,
+      "dataLength": 225937,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.237",
+      "timestamp": 47330.15287,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.237",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.238",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/ac-films/6.8.2/styles/modal.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.152967,
+      "wallTime": 1671216914.55379,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1479,
+        "columnNumber": 68
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Stylesheet",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.238",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.679116,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.apple.com/ac/ac-films/6.8.2/styles/modal.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "content-encoding": "gzip",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "x-cache-remote": "TCP_IMS_HIT from a184-30-41-158.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "server": "Apple",
+          "ntcoent-length": "111126",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "text/css",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "cache-control": "max-age=300",
+          "content-length": "16768",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:00:05 GMT"
+        },
+        "mimeType": "text/css",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47330.664393,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.074,
+          "sendEnd": 0.074,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 13.89
+        },
+        "responseTime": 1671216905465.271,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.238",
+      "timestamp": 47330.679145,
+      "dataLength": 111126,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.238",
+      "timestamp": 47330.678833,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.238",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.238",
+      "wallTime": 1671216914.807,
+      "timestamp": 47330.40607094765
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.239",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/ac-films/6.8.2/scripts/autofilms.built.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.153209,
+      "wallTime": 1671216914.554033,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1480,
+        "columnNumber": 83
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.239"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.239",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.153348,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/ac/ac-films/6.8.2/scripts/autofilms.built.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "application/x-javascript",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=109",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:56:54 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 87912,
+        "timing": {
+          "requestTime": 47320.617308,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.093,
+          "sendEnd": 0.144,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 471.99
+        },
+        "responseTime": 1671216905490.053,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.239",
+      "timestamp": 47330.153359,
+      "dataLength": 412274,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.239",
+      "timestamp": 47330.153361,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.239",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.240",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/metrics/data-relay/1.1.4/scripts/data-relay.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.153401,
+      "wallTime": 1671216914.554251,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1483,
+        "columnNumber": 101
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.240",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.716097,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/metrics/data-relay/1.1.4/scripts/data-relay.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:15 GMT",
+          "content-encoding": "gzip",
+          "server": "Apple",
+          "vary": "Accept-Encoding",
+          "x-frame-options": "SAMEORIGIN",
+          "content-type": "application/x-javascript",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=0",
+          "content-length": "4955",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:15 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 712,
+        "timing": {
+          "requestTime": 47330.665778,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.146,
+          "sendEnd": 0.244,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 49.403
+        },
+        "responseTime": 1671216915115.862,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.240",
+      "timestamp": 47330.716146,
+      "dataLength": 15652,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.240",
+      "timestamp": 47330.716727,
+      "dataLength": 0,
+      "encodedDataLength": 4991
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.240",
+      "timestamp": 47330.715597,
+      "encodedDataLength": 5703,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.240",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.240",
+      "wallTime": 1671216914.809,
+      "timestamp": 47330.40807104111
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.241",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/metrics/data-relay/1.1.4/scripts/auto-relay.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.153594,
+      "wallTime": 1671216914.554419,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1484,
+        "columnNumber": 101
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Script",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.241"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.241",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.153742,
+      "type": "Script",
+      "response": {
+        "url": "https://www.apple.com/metrics/data-relay/1.1.4/scripts/auto-relay.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:05 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "application/x-javascript",
+          "cache-control": "max-age=52",
+          "content-length": "197",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:55:57 GMT"
+        },
+        "mimeType": "application/x-javascript",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 908,
+        "timing": {
+          "requestTime": 47320.619759,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.07,
+          "sendEnd": 0.174,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 387.233
+        },
+        "responseTime": 1671216905407.738,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.241",
+      "timestamp": 47330.153752,
+      "dataLength": 197,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.241",
+      "timestamp": 47330.153754,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.241",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.293",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_semibold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.742605,
+      "wallTime": 1671216915.143432,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.293"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.293",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.742683,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_semibold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:47 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=1649",
+          "content-length": "231048",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:22:35 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 232298,
+        "timing": {
+          "requestTime": 47322.152018,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.114,
+          "sendEnd": 0.18,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.533
+        },
+        "responseTime": 1671216906599.352,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.293",
+      "timestamp": 47330.742689,
+      "dataLength": 231048,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.293",
+      "timestamp": 47330.742691,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.293",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.299",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_bold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.74278,
+      "wallTime": 1671216915.143592,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.299"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.299",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.742827,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_bold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:46 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=2075",
+          "content-length": "229396",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:29:41 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 230637,
+        "timing": {
+          "requestTime": 47322.189746,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.054,
+          "sendEnd": 0.086,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 40.194
+        },
+        "responseTime": 1671216906630.711,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.299",
+      "timestamp": 47330.742833,
+      "dataLength": 229396,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.299",
+      "timestamp": 47330.742834,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.299",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.317",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_regular.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.743077,
+      "wallTime": 1671216915.143889,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.317"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.317",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.743126,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Display/v3/sf-pro-display_regular.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:47 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=1326",
+          "content-length": "215624",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:17:12 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 216838,
+        "timing": {
+          "requestTime": 47322.155355,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.077,
+          "sendEnd": 0.135,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.909
+        },
+        "responseTime": 1671216906603.049,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.317",
+      "timestamp": 47330.743132,
+      "dataLength": 215624,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.317",
+      "timestamp": 47330.743134,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.317",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.347",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_semibold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.743503,
+      "wallTime": 1671216915.144318,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.347"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.347",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.743549,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_semibold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:55:06 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=1572",
+          "content-length": "234260",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:21:18 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 235510,
+        "timing": {
+          "requestTime": 47322.079473,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.111,
+          "sendEnd": 0.226,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 41.434
+        },
+        "responseTime": 1671216906521.666,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.347",
+      "timestamp": 47330.743555,
+      "dataLength": 234260,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.347",
+      "timestamp": 47330.743556,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.347",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.353",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_bold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.743644,
+      "wallTime": 1671216915.144458,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.353"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.353",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.743692,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_bold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:55:05 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=2482",
+          "content-length": "232592",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:36:28 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 233842,
+        "timing": {
+          "requestTime": 47322.188792,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.12,
+          "sendEnd": 0.184,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.878
+        },
+        "responseTime": 1671216906634.462,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.353",
+      "timestamp": 47330.743698,
+      "dataLength": 232592,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.353",
+      "timestamp": 47330.743699,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.353",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.371",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_regular.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.743933,
+      "wallTime": 1671216915.144744,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.371"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.371",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.743976,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Text/v3/sf-pro-text_regular.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:55:05 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=1975",
+          "content-length": "220536",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:28:01 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 221759,
+        "timing": {
+          "requestTime": 47322.079631,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.075,
+          "sendEnd": 0.099,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.974
+        },
+        "responseTime": 1671216906525.382,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.371",
+      "timestamp": 47330.743981,
+      "dataLength": 220536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.371",
+      "timestamp": 47330.743984,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.371",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.389",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Icons/v3/sf-pro-icons_bold.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.744232,
+      "wallTime": 1671216915.145045,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.389"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.389",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.74428,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Icons/v3/sf-pro-icons_bold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:50 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=515",
+          "content-length": "11756",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:03:41 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 12521,
+        "timing": {
+          "requestTime": 47322.189544,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.059,
+          "sendEnd": 0.108,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 47.331
+        },
+        "responseTime": 1671216906637.644,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.389",
+      "timestamp": 47330.744285,
+      "dataLength": 11756,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.389",
+      "timestamp": 47330.744286,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.389",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.398",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Icons/v3/sf-pro-icons_regular.woff2",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3",
+          "Origin": "https://www.apple.com",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.744402,
+      "wallTime": 1671216915.145216,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/wss/fonts?families=SF+Pro,v3|SF+Pro+Icons,v3"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Font",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.398"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.398",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.744448,
+      "type": "Font",
+      "response": {
+        "url": "https://www.apple.com/wss/fonts/SF-Pro-Icons/v3/sf-pro-icons_regular.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 16 Jun 2022 22:54:50 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "font/woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, max-age=936",
+          "content-length": "11208",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:10:42 GMT"
+        },
+        "mimeType": "font/woff2",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 11973,
+        "timing": {
+          "requestTime": 47322.155635,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.081,
+          "sendEnd": 0.132,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 42.632
+        },
+        "responseTime": 1671216906599.028,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.398",
+      "timestamp": 47330.744453,
+      "dataLength": 11208,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.398",
+      "timestamp": 47330.744456,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.398",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.401",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_apple_image__b5er5ngrzxqq_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.744992,
+      "wallTime": 1671216915.145805,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.401"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.401",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.745054,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_apple_image__b5er5ngrzxqq_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cneonction": "close",
+          "nncoection": "close",
+          "content-length": "506",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Sun, 24 Oct 2021 03:40:19 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=73",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:19 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1291,
+        "timing": {
+          "requestTime": 47321.566561,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.166,
+          "sendEnd": 0.268,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.14
+        },
+        "responseTime": 1671216906011.45,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.401",
+      "timestamp": 47330.745059,
+      "dataLength": 863,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.401",
+      "timestamp": 47330.745061,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.401",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.402",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_store_image__c7jy08initqq_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.74513,
+      "wallTime": 1671216915.145944,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.402"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.402",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.745179,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_store_image__c7jy08initqq_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "962",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=426",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:02:12 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1708,
+        "timing": {
+          "requestTime": 47321.567038,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.178,
+          "sendEnd": 0.284,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 44.071
+        },
+        "responseTime": 1671216906011.89,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.402",
+      "timestamp": 47330.745184,
+      "dataLength": 2512,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.402",
+      "timestamp": 47330.745192,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.402",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.403",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_mac_image__dazlko3t9a6a_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.745242,
+      "wallTime": 1671216915.146054,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.403"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.403",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.745289,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_mac_image__dazlko3t9a6a_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "598",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=78",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:24 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1355,
+        "timing": {
+          "requestTime": 47321.567122,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.134,
+          "sendEnd": 0.202,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 48.028
+        },
+        "responseTime": 1671216906015.905,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.403",
+      "timestamp": 47330.745294,
+      "dataLength": 1105,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.403",
+      "timestamp": 47330.745296,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.403",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.404",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_ipad_image__fw9qyj9lloi2_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.745344,
+      "wallTime": 1671216915.146157,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.404"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.404",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.745392,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_ipad_image__fw9qyj9lloi2_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "content-length": "634",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=63",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:09 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1405,
+        "timing": {
+          "requestTime": 47321.567562,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.092,
+          "sendEnd": 0.174,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 47.959
+        },
+        "responseTime": 1671216906016.294,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.404",
+      "timestamp": 47330.745397,
+      "dataLength": 1164,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.404",
+      "timestamp": 47330.745399,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.404",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.405",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_iphone_image__ko7x4isga4ia_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.745445,
+      "wallTime": 1671216915.146257,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.405"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.405",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.745495,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_iphone_image__ko7x4isga4ia_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "692",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=81",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:27 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1438,
+        "timing": {
+          "requestTime": 47321.567744,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.078,
+          "sendEnd": 0.121,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 48.145
+        },
+        "responseTime": 1671216906016.671,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.405",
+      "timestamp": 47330.7455,
+      "dataLength": 1405,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.405",
+      "timestamp": 47330.745502,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.405",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.406",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_watch_image__gkoblojrlsqe_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.745548,
+      "wallTime": 1671216915.14636,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.406"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.406",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.745597,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_watch_image__gkoblojrlsqe_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "unused62": "8096267",
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (A)",
+          "nncoection": "close",
+          "content-length": "683",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=49",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:55:55 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1468,
+        "timing": {
+          "requestTime": 47321.569217,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.079,
+          "sendEnd": 0.138,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 42.157
+        },
+        "responseTime": 1671216906012.155,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.406",
+      "timestamp": 47330.745603,
+      "dataLength": 1309,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.406",
+      "timestamp": 47330.745604,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.406",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.408",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_airpods_image__f969s84ivmaa_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.752013,
+      "wallTime": 1671216915.152835,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.408"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.408",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.752091,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_airpods_image__f969s84ivmaa_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "content-length": "854",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=98",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:44 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1625,
+        "timing": {
+          "requestTime": 47321.599015,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.089,
+          "sendEnd": 0.155,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.524
+        },
+        "responseTime": 1671216906061.329,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.408",
+      "timestamp": 47330.752098,
+      "dataLength": 1722,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.408",
+      "timestamp": 47330.7521,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.408",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.409",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_tvhome_image__zb2ewyxbi6ae_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.752174,
+      "wallTime": 1671216915.152989,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.409"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.409",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.752221,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_tvhome_image__zb2ewyxbi6ae_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "1072",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=107",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:53 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1818,
+        "timing": {
+          "requestTime": 47321.599391,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.071,
+          "sendEnd": 0.157,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.388
+        },
+        "responseTime": 1671216906061.561,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.409",
+      "timestamp": 47330.752226,
+      "dataLength": 2194,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.409",
+      "timestamp": 47330.752228,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.409",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.410",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_onlyonapple_image__c4t8k97tougm_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.752278,
+      "wallTime": 1671216915.15309,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.410"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.410",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.752321,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_onlyonapple_image__c4t8k97tougm_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' data: blob: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "1209",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=533",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:03:59 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1951,
+        "timing": {
+          "requestTime": 47321.599552,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.064,
+          "sendEnd": 0.105,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.504
+        },
+        "responseTime": 1671216906061.854,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.410",
+      "timestamp": 47330.752327,
+      "dataLength": 3177,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.410",
+      "timestamp": 47330.752328,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.410",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.411",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_accessories_image__edj0wqmfwxyu_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.752374,
+      "wallTime": 1671216915.153185,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.411"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.411",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.752418,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_accessories_image__edj0wqmfwxyu_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cneonction": "close",
+          "nncoection": "close",
+          "content-length": "1066",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=431",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:02:17 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1851,
+        "timing": {
+          "requestTime": 47321.599856,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.084,
+          "sendEnd": 0.142,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.366
+        },
+        "responseTime": 1671216906062.025,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.411",
+      "timestamp": 47330.752423,
+      "dataLength": 3656,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.411",
+      "timestamp": 47330.752424,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.411",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.412",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_support_image__bw9kctll7u3m_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.752475,
+      "wallTime": 1671216915.153287,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.412"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.412",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.75252,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_links_support_image__bw9kctll7u3m_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "content-length": "869",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=350",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 19:00:56 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1640,
+        "timing": {
+          "requestTime": 47321.600218,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.073,
+          "sendEnd": 0.119,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.15
+        },
+        "responseTime": 1671216906062.173,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.412",
+      "timestamp": 47330.752525,
+      "dataLength": 1934,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.412",
+      "timestamp": 47330.752526,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.412",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.413",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_search_image__cbllq1gkias2_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.752572,
+      "wallTime": 1671216915.153381,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.413"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.413",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.752611,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_search_image__cbllq1gkias2_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-length": "251",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=79",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:25 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 996,
+        "timing": {
+          "requestTime": 47321.600398,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.058,
+          "sendEnd": 0.101,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 61.146
+        },
+        "responseTime": 1671216906062.337,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.413",
+      "timestamp": 47330.752616,
+      "dataLength": 541,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.413",
+      "timestamp": 47330.752618,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.413",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.414",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_bag_image__yzte50i47ciu_large.svg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": true
+      },
+      "timestamp": 47330.752674,
+      "wallTime": 1671216915.153486,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/styles/ac-globalnav.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.414"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.414",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.752715,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_bag_image__yzte50i47ciu_large.svg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "content-encoding": "gzip",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "nncoection": "close",
+          "content-length": "298",
+          "x-xss-protection": "1; mode=block",
+          "last-modified": "Thu, 14 Oct 2021 23:19:28 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "image/svg+xml",
+          "cache-control": "max-age=93",
+          "accept-ranges": "bytes",
+          "expires": "Fri, 16 Dec 2022 18:56:39 GMT"
+        },
+        "mimeType": "image/svg+xml",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1069,
+        "timing": {
+          "requestTime": 47321.600773,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.068,
+          "sendEnd": 0.112,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 60.978
+        },
+        "responseTime": 1671216906062.548,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.414",
+      "timestamp": 47330.75272,
+      "dataLength": 477,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.414",
+      "timestamp": 47330.752722,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.414",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.418",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/ac/localeswitcher/4/en_US/content/localeswitcher.json",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.787489,
+      "wallTime": 1671216915.188321,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "value",
+              "scriptId": "49",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 180076
+            },
+            {
+              "functionName": "e",
+              "scriptId": "49",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 179268
+            },
+            {
+              "functionName": "175.176",
+              "scriptId": "49",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 178568
+            },
+            {
+              "functionName": "i",
+              "scriptId": "49",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 253
+            },
+            {
+              "functionName": "e",
+              "scriptId": "49",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 413
+            },
+            {
+              "functionName": "",
+              "scriptId": "49",
+              "url": "https://www.apple.com/ac/localeswitcher/4/en_US/scripts/localeswitcher.built.js",
+              "lineNumber": 0,
+              "columnNumber": 430
+            }
+          ]
+        }
+      },
+      "redirectHasExtraInfo": false,
+      "type": "XHR",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.418",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47331.296855,
+      "type": "XHR",
+      "response": {
+        "url": "https://www.apple.com/ac/localeswitcher/4/en_US/content/localeswitcher.json",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' data: blob: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "content-encoding": "gzip",
+          "x-content-type-options": "nosniff",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "last-modified": "Thu, 14 Oct 2021 23:19:29 GMT",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "vary": "Accept-Encoding",
+          "content-type": "application/json",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "cache-control": "max-age=70",
+          "accept-ranges": "bytes",
+          "content-length": "392",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:56:16 GMT"
+        },
+        "mimeType": "application/json",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47331.290596,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.24,
+          "sendEnd": 0.24,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 5.259
+        },
+        "responseTime": 1671216906081.753,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.418",
+      "timestamp": 47331.296905,
+      "dataLength": 1331,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.418",
+      "timestamp": 47331.296167,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.418",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.418",
+      "wallTime": 1671216915.439,
+      "timestamp": 47331.03807091713
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.420",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-card-december/card_logo__b0k9gna8xemu_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.797873,
+      "wallTime": 1671216915.19869,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.420"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.420",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.797935,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-card-december/card_logo__b0k9gna8xemu_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=1837",
+          "accept-ranges": "bytes",
+          "content-length": "2934",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:25:43 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 3710,
+        "timing": {
+          "requestTime": 47321.66197,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.298,
+          "sendEnd": 0.443,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.279
+        },
+        "responseTime": 1671216906109.053,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.420",
+      "timestamp": 47330.79794,
+      "dataLength": 2934,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.420",
+      "timestamp": 47330.797942,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.420",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.421",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/airpods-holiday-2022/promo_logo_airpods_holiday__uzkw355klvmy_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.798352,
+      "wallTime": 1671216915.199162,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.421"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.421",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.798389,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/airpods-holiday-2022/promo_logo_airpods_holiday__uzkw355klvmy_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=2792",
+          "accept-ranges": "bytes",
+          "content-length": "815",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:41:38 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 1582,
+        "timing": {
+          "requestTime": 47321.662001,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.292,
+          "sendEnd": 0.443,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.418
+        },
+        "responseTime": 1671216906109.226,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.421",
+      "timestamp": 47330.798393,
+      "dataLength": 815,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.421",
+      "timestamp": 47330.798394,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.421",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.422",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-watch-series-8/promo_logo_apple_watch_series_8__ee6riplsucuq_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.798493,
+      "wallTime": 1671216915.199304,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.422"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.422",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.798532,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-watch-series-8/promo_logo_apple_watch_series_8__ee6riplsucuq_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=2487",
+          "accept-ranges": "bytes",
+          "content-length": "2785",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:36:33 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 3561,
+        "timing": {
+          "requestTime": 47321.662025,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.282,
+          "sendEnd": 0.42,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.532
+        },
+        "responseTime": 1671216906109.364,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.422",
+      "timestamp": 47330.798536,
+      "dataLength": 2785,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.422",
+      "timestamp": 47330.798537,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.422",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.423",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-watch-ultra/promo_logo_apple_watch_ultra__ebzaahharnue_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.798643,
+      "wallTime": 1671216915.199452,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.423"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.423",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.798677,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/apple-watch-ultra/promo_logo_apple_watch_ultra__ebzaahharnue_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=3046",
+          "accept-ranges": "bytes",
+          "content-length": "2311",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:45:52 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 3078,
+        "timing": {
+          "requestTime": 47321.662074,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.247,
+          "sendEnd": 0.371,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.623
+        },
+        "responseTime": 1671216906109.505,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.423",
+      "timestamp": 47330.798682,
+      "dataLength": 2311,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.423",
+      "timestamp": 47330.798683,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.423",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.424",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/arcade/logo_light__cfvl40z2nzau_large.png",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.79882,
+      "wallTime": 1671216915.199628,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.424"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.424",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.798852,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/logos/arcade/logo_light__cfvl40z2nzau_large.png",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:53 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/png",
+          "cache-control": "max-age=3280",
+          "accept-ranges": "bytes",
+          "content-length": "2497",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:49:46 GMT"
+        },
+        "mimeType": "image/png",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 3264,
+        "timing": {
+          "requestTime": 47321.662098,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.236,
+          "sendEnd": 0.348,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 45.902
+        },
+        "responseTime": 1671216906108.782,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.424",
+      "timestamp": 47330.798857,
+      "dataLength": 2497,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.424",
+      "timestamp": 47330.798857,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.424",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.429",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/a_voEGGOjHGvUUhwrbStXQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.827647,
+      "wallTime": 1671216915.228466,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.429"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.429",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.827738,
+      "type": "Image",
+      "response": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/a_voEGGOjHGvUUhwrbStXQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "S4WPP7BREK7236BIRDVI5N7QCM",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "972cf7fc3122bfadf82888ea8eb7f013",
+          "x-daiquiri-instance": "daiquiri:13624002:mr85p00it-hyhk03094901:7987:22HOTFIX10:daiquiri-amp-processing-shared-int-001-mr",
+          "cdnuuid": "2a43a61a-5e3c-49b3-a1c0-fc69934bb5b9-1986660428",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "972cf7fc3122bfadf82888ea8eb7f013-95c935128de9cfd6",
+          "content-length": "150240",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Tue, 15 Nov 2022 09:47:36 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY4NTA1NjU2NzQ5LGlzQnVpbGRWZXJzaW9uTm90U2V0LDUwMDY4LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "972cf7fc-3122-bfad-f828-88ea8eb7f013",
+          "x-b3-spanid": "95c935128de9cfd6",
+          "cache-control": "no-transform, max-age=13429930",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": false,
+        "connectionId": 206,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 151396,
+        "timing": {
+          "requestTime": 47321.683015,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.341,
+          "dnsEnd": 24.083,
+          "connectStart": 24.083,
+          "connectEnd": 83.457,
+          "sslStart": 40.056,
+          "sslEnd": 83.454,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 83.914,
+          "sendEnd": 84.03,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 104.37
+        },
+        "responseTime": 1671216906188.177,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.429",
+      "timestamp": 47330.827747,
+      "dataLength": 150240,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.429",
+      "timestamp": 47330.827748,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.429",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.430",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is5-ssl.mzstatic.com/image/thumb/lgskq6n1xkUI5DOyA5tWWQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.827903,
+      "wallTime": 1671216915.228712,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.430"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.430",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.827959,
+      "type": "Image",
+      "response": {
+        "url": "https://is5-ssl.mzstatic.com/image/thumb/lgskq6n1xkUI5DOyA5tWWQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "TDXTAGLZB3XZI2AJLIAKINC2H4",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "98ef3019790eef9468095a00a4345a3f",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE175:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "5e97e60b-50e2-4ae6-88da-9d1655ff6eee-2705293982",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "98ef3019790eef9468095a00a4345a3f-bbff866c81eddd39",
+          "content-length": "118817",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Fri, 02 Dec 2022 13:04:39 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY5OTg2Mjc5NzAyLGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMDk3LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "98ef3019-790e-ef94-6809-5a00a4345a3f",
+          "x-b3-spanid": "bbff866c81eddd39",
+          "cache-control": "no-transform, max-age=15502754",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": false,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 119905,
+        "timing": {
+          "requestTime": 47321.683128,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.032,
+          "dnsEnd": 24.222,
+          "connectStart": 24.222,
+          "connectEnd": 81.529,
+          "sslStart": 40.071,
+          "sslEnd": 81.524,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 81.741,
+          "sendEnd": 81.831,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 113.245
+        },
+        "responseTime": 1671216906197.147,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.430",
+      "timestamp": 47330.827969,
+      "dataLength": 118817,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.430",
+      "timestamp": 47330.82797,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.430",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.431",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/GT66HoV8VJL1IZwaqos_TQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.828051,
+      "wallTime": 1671216915.228859,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.431"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.431",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.8281,
+      "type": "Image",
+      "response": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/GT66HoV8VJL1IZwaqos_TQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "P62AXEJW67XW23G4TQ4CR5FI64",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "7fb40b9136f7ef6d6cdc9c3828f4a8f7",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE104:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "bccc1c4a-6cf0-4f75-afe8-2ce87a180321-671224242",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "7fb40b9136f7ef6d6cdc9c3828f4a8f7-c59fd132c7681c6a",
+          "content-length": "170028",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Mon, 15 Aug 2022 04:52:47 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjYwNTM5MTY3MDY5LGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMTc5LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "7fb40b91-36f7-ef6d-6cdc-9c3828f4a8f7",
+          "x-b3-spanid": "c59fd132c7681c6a",
+          "cache-control": "no-transform, max-age=11619582",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 206,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 171229,
+        "timing": {
+          "requestTime": 47321.683295,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 83.659,
+          "sendEnd": 83.75,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 102.021
+        },
+        "responseTime": 1671216906186.104,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.431",
+      "timestamp": 47330.828107,
+      "dataLength": 170028,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.431",
+      "timestamp": 47330.828108,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.431",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.432",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/IZLh7W9XMi2iYTPqqFwRYg/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.828182,
+      "wallTime": 1671216915.228991,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.432"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.432",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.828232,
+      "type": "Image",
+      "response": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/IZLh7W9XMi2iYTPqqFwRYg/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "BMUAKDJJWLTO7PITBHESLU22VQ",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "0b28050d29b2e6efbd1309c925d35aac",
+          "x-daiquiri-instance": "daiquiri:13624002:mr85p00it-hyhk03094901:7987:22RELEASE175:daiquiri-amp-processing-shared-int-001-mr",
+          "cdnuuid": "57e0bcaa-bd59-4467-9caa-e63b9e24c1f3-1566828557",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "0b28050d29b2e6efbd1309c925d35aac-0bbb274d1ff57879",
+          "content-length": "144789",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Fri, 02 Dec 2022 02:01:06 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY5OTQ2NDY2MTcyLGlzQnVpbGRWZXJzaW9uTm90U2V0LDUwMTQ1LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "0b28050d-29b2-e6ef-bd13-09c925d35aac",
+          "x-b3-spanid": "0bbb274d1ff57879",
+          "cache-control": "no-transform, max-age=15059708",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 206,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 145929,
+        "timing": {
+          "requestTime": 47321.708807,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 58.162,
+          "sendEnd": 58.239,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 97.358
+        },
+        "responseTime": 1671216906206.925,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.432",
+      "timestamp": 47330.828239,
+      "dataLength": 144789,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.432",
+      "timestamp": 47330.82824,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.432",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.433",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is4-ssl.mzstatic.com/image/thumb/P-HquLNfkzU1g_Wx0-eZUA/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.828308,
+      "wallTime": 1671216915.229116,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.433"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.433",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.828355,
+      "type": "Image",
+      "response": {
+        "url": "https://is4-ssl.mzstatic.com/image/thumb/P-HquLNfkzU1g_Wx0-eZUA/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "WNEYYJESMLEKETBDGVVF2FOK6E",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "b3498c249262c8a24c23356a5d15caf1",
+          "x-daiquiri-instance": "daiquiri:43624002:st44p00it-hyhk15014701:7987:22RELEASE175:daiquiri-amp-processing-shared-int-001-st",
+          "cdnuuid": "85e468cb-0027-4652-83f5-eb166f6fba36-198184469",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "b3498c249262c8a24c23356a5d15caf1-329bde75ac36dc42",
+          "content-length": "93775",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Tue, 13 Dec 2022 19:50:46 GMT",
+          "etag": "\"MSwxLjMuMS0yMlAsVmVyc2lvbiAxMi4xIChCdWlsZCAyMUM1MiksMTY3MDk2MTA0NjYzNCxpc0J1aWxkVmVyc2lvbk5vdFNldCw3MDM4NSxub0VmZmVjdA==\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "b3498c24-9262-c8a2-4c23-356a5d15caf1",
+          "x-b3-spanid": "329bde75ac36dc42",
+          "cache-control": "no-transform, max-age=15461754",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": false,
+        "connectionId": 231,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 94806,
+        "timing": {
+          "requestTime": 47321.708846,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.18,
+          "dnsEnd": 24.973,
+          "connectStart": 24.973,
+          "connectEnd": 76.149,
+          "sslStart": 40.852,
+          "sslEnd": 76.145,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 76.229,
+          "sendEnd": 76.29,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 98.48
+        },
+        "responseTime": 1671216906208.103,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.433",
+      "timestamp": 47330.828362,
+      "dataLength": 93775,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.433",
+      "timestamp": 47330.828363,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.433",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.434",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is1-ssl.mzstatic.com/image/thumb/gkWjLqLfF8Pahc6a6Udtxg/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.828429,
+      "wallTime": 1671216915.229238,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.434"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.434",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.828479,
+      "type": "Image",
+      "response": {
+        "url": "https://is1-ssl.mzstatic.com/image/thumb/gkWjLqLfF8Pahc6a6Udtxg/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "3S3CC7ECSPLZAPGPTXSJB25EDY",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "dcb6217c8293d7903ccf9de490eba41e",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE175:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "85e468cb-0027-4652-83f5-eb166f6fba36-17201806",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "dcb6217c8293d7903ccf9de490eba41e-fb9dd7faa7a4e5af",
+          "content-length": "154727",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Mon, 12 Dec 2022 21:30:02 GMT",
+          "etag": "\"MSwxLjMuMS0yMlAsVmVyc2lvbiAxMi4xIChCdWlsZCAyMUM1MiksMTY3MDg4MDYwMjk2Mixpc0J1aWxkVmVyc2lvbk5vdFNldCw2MDIyMSxub0VmZmVjdA==\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "dcb6217c-8293-d790-3ccf-9de490eba41e",
+          "x-b3-spanid": "fb9dd7faa7a4e5af",
+          "cache-control": "no-transform, max-age=15315640",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 155893,
+        "timing": {
+          "requestTime": 47321.754272,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 42.537,
+          "sendEnd": 42.6,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 76.612
+        },
+        "responseTime": 1671216906231.672,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.434",
+      "timestamp": 47330.828486,
+      "dataLength": 154727,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.434",
+      "timestamp": 47330.828487,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.434",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.435",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/CXnyehPcDHEauavhg0D79Q/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.828552,
+      "wallTime": 1671216915.22936,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.435"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.435",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.828604,
+      "type": "Image",
+      "response": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/CXnyehPcDHEauavhg0D79Q/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "OCUC7J3DB3AKLXYTD4WUVORQWU",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "70a82fa7630ec0a5df131f2d4aba30b5",
+          "x-daiquiri-instance": "daiquiri:43624002:st44p00it-hyhk15014701:7987:22RELEASE133:daiquiri-amp-processing-shared-int-001-st",
+          "cdnuuid": "67ee4fbb-d8ef-4b80-b7d6-6ec2a1eae029-2076014961",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "70a82fa7630ec0a5df131f2d4aba30b5-95a6381e78681ba4",
+          "content-length": "111622",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Mon, 10 Oct 2022 17:00:26 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY1NDIxMjI2ODg2LGlzQnVpbGRWZXJzaW9uTm90U2V0LDcwNDM0LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "70a82fa7-630e-c0a5-df13-1f2d4aba30b5",
+          "x-b3-spanid": "95a6381e78681ba4",
+          "cache-control": "no-transform, max-age=11309339",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 112689,
+        "timing": {
+          "requestTime": 47321.754322,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 24.741,
+          "sendEnd": 24.833,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 68.887
+        },
+        "responseTime": 1671216906223.978,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.435",
+      "timestamp": 47330.828611,
+      "dataLength": 111622,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.435",
+      "timestamp": 47330.828612,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.435",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.436",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/EuF6BWsgBeic_Ap2qeAGBQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.828677,
+      "wallTime": 1671216915.229485,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.436"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.436",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.828723,
+      "type": "Image",
+      "response": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/EuF6BWsgBeic_Ap2qeAGBQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "R2XVRDZVOTDJIARMNOQLKRDSGI",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "8eaf588f3574c694022c6ba0b5447232",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE148:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "702e0c1f-ed84-4427-b61a-e8d0ec18c08b-394237496",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "8eaf588f3574c694022c6ba0b5447232-428bfc6bb7b28c6e",
+          "content-length": "140803",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Wed, 23 Nov 2022 01:58:58 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY5MTY4NzM4MDgzLGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMDk2LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "8eaf588f-3574-c694-022c-6ba0b5447232",
+          "x-b3-spanid": "428bfc6bb7b28c6e",
+          "cache-control": "no-transform, max-age=14830970",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 141936,
+        "timing": {
+          "requestTime": 47321.75434,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 24.754,
+          "sendEnd": 24.816,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 71.116
+        },
+        "responseTime": 1671216906226.242,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.436",
+      "timestamp": 47330.82873,
+      "dataLength": 140803,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.436",
+      "timestamp": 47330.828731,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.436",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.437",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is5-ssl.mzstatic.com/image/thumb/7SeRlnCzKlgeqrg6-ixkig/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.828796,
+      "wallTime": 1671216915.229605,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.437"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.437",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.828849,
+      "type": "Image",
+      "response": {
+        "url": "https://is5-ssl.mzstatic.com/image/thumb/7SeRlnCzKlgeqrg6-ixkig/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "ZS6I5SB6Y4NOIZHPROBQM4KZV4",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "ccbc8ec83ec71ae464ef8b83067159af",
+          "x-daiquiri-instance": "daiquiri:43624002:st44p00it-hyhk15014701:7987:22RELEASE113:daiquiri-amp-processing-shared-int-001-st",
+          "cdnuuid": "df5ec70d-4d9f-4d3b-be4a-efc204e04128-3665563834",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "ccbc8ec83ec71ae464ef8b83067159af-5709db562dfacd8b",
+          "content-length": "157456",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Wed, 14 Sep 2022 14:03:21 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjYzMTY0MjAxNjkyLGlzQnVpbGRWZXJzaW9uTm90U2V0LDcwMzgxLG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "ccbc8ec8-3ec7-1ae4-64ef-8b83067159af",
+          "x-b3-spanid": "5709db562dfacd8b",
+          "cache-control": "no-transform, max-age=13609318",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 158634,
+        "timing": {
+          "requestTime": 47321.754357,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 10.542,
+          "sendEnd": 10.609,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 27.723
+        },
+        "responseTime": 1671216906182.848,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.437",
+      "timestamp": 47330.828856,
+      "dataLength": 157456,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.437",
+      "timestamp": 47330.828857,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.437",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.438",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/78-I7VenST4ztZYfwMf6AQ/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.828924,
+      "wallTime": 1671216915.229733,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.438"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.438",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.828972,
+      "type": "Image",
+      "response": {
+        "url": "https://is2-ssl.mzstatic.com/image/thumb/78-I7VenST4ztZYfwMf6AQ/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "HW3EMAZLBBNEVBM42NXGC5JTAE",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "3db646032b085a4a859cd36e61753301",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22RELEASE91:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "96ac4f6b-254e-4c43-818a-d41d3950b824-5944867109",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "3db646032b085a4a859cd36e61753301-15329ea29c5336aa",
+          "content-length": "100601",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Thu, 28 Jul 2022 03:01:53 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjU4OTc3MzEzMjk4LGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMzEwLG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "3db64603-2b08-5a4a-859c-d36e61753301",
+          "x-b3-spanid": "15329ea29c5336aa",
+          "cache-control": "no-transform, max-age=14054802",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 206,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 101651,
+        "timing": {
+          "requestTime": 47321.754374,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 12.606,
+          "sendEnd": 12.672,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 56.059
+        },
+        "responseTime": 1671216906211.203,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.438",
+      "timestamp": 47330.828979,
+      "dataLength": 100601,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.438",
+      "timestamp": 47330.82898,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.438",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.439",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/AWDRdQz0nepFpnsUNiTDuw/980x551.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isSameSite": false
+      },
+      "timestamp": 47330.829045,
+      "wallTime": 1671216915.229853,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/",
+        "lineNumber": 1503,
+        "columnNumber": 1
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.439"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.439",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.829092,
+      "type": "Image",
+      "response": {
+        "url": "https://is3-ssl.mzstatic.com/image/thumb/AWDRdQz0nepFpnsUNiTDuw/980x551.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "x-apple-jingle-correlation-key": "POYHAAZJN42U5CSIXRPRSRK25Y",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-b3-traceid": "7bb07003296f354e8a48bc5f19455aee",
+          "x-daiquiri-instance": "daiquiri:33624002:pv50p00it-hyhk12033901:7987:22HOTFIX7:daiquiri-amp-processing-shared-int-001-pv",
+          "cdnuuid": "5feeff8f-85f9-46d9-a18d-4f0e37d30fb3-3333223677",
+          "x-cache": "TCP_HIT from a23-33-141-14.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "b3": "7bb07003296f354e8a48bc5f19455aee-87f59c9448d6e386",
+          "content-length": "130884",
+          "apple-tk": "false",
+          "server": "daiquiri/3.0.0",
+          "apple-seq": "0.0",
+          "last-modified": "Sat, 24 Sep 2022 08:23:50 GMT",
+          "etag": "\"MSwxLjI4LTIySCxWZXJzaW9uIDEyLjEgKEJ1aWxkIDIxQzUyKSwxNjY0MDA3ODMwNTMwLGlzQnVpbGRWZXJzaW9uTm90U2V0LDYwMDQ0LG5vRWZmZWN0\"",
+          "apple-originating-system": "UnknownOriginatingSystem",
+          "content-type": "image/jpeg",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "Content-Length,Content-Type,ETag,Cache-Control,Expires,Last-Modified",
+          "x-apple-request-uuid": "7bb07003-296f-354e-8a48-bc5f19455aee",
+          "x-b3-spanid": "87f59c9448d6e386",
+          "cache-control": "no-transform, max-age=13611133",
+          "timing-allow-origin": "*"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 207,
+        "remoteIPAddress": "23.32.252.28",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 131999,
+        "timing": {
+          "requestTime": 47321.826423,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.166,
+          "sendEnd": 0.202,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 32.721
+        },
+        "responseTime": 1671216906259.915,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "itunes.apple.com",
+          "sanList": [
+            "is4-ssl.mzstatic.com",
+            "xp.apple.com",
+            "amp-api-edge.apps.apple.com",
+            "store.mzstatic.com",
+            "a2.mzstatic.com",
+            "b2.mzstatic.com",
+            "api.podcasts.apple.com",
+            "sf-api-token-service.itunes.apple.com",
+            "music.apple.com",
+            "partiality.itunes.apple.com",
+            "siri-search.itunes.apple.com",
+            "configuration.apple.com",
+            "s4.mzstatic.com",
+            "s.mzstatic.com",
+            "s1.mzstatic.com",
+            "sb.tv.apple.com",
+            "apps.apple.com",
+            "api.books.apple.com",
+            "b3.mzstatic.com",
+            "pcr.apple.com",
+            "radio-activity.itunes.apple.com",
+            "amp-api-edge.music.apple.com",
+            "vpp-app.itunes.apple.com",
+            "api.apps.apple.com",
+            "api.edu.apple.com",
+            "books.apple.com",
+            "b5.mzstatic.com",
+            "metrics.mzstatic.com",
+            "upp.itunes.apple.com",
+            "apps.mzstatic.com",
+            "radio.itunes.apple.com",
+            "sb.music.apple.com",
+            "desktop-music.itunes.apple.com",
+            "amp-api.podcasts.apple.com",
+            "api.videos.apple.com",
+            "is2-ssl.mzstatic.com",
+            "s2.mzstatic.com",
+            "tf-feedback.itunes.apple.com",
+            "is3-ssl.mzstatic.com",
+            "tv.apple.com",
+            "desktop-music-legacy.itunes.apple.com",
+            "pd.itunes.apple.com",
+            "a3.mzstatic.com",
+            "amp-api-search-edge.apps.apple.com",
+            "api.itunes.apple.com",
+            "itc.mzstatic.com",
+            "sp.itunes.apple.com",
+            "is5-ssl.mzstatic.com",
+            "sitemaps.itunes.apple.com",
+            "atve.tv.apple.com",
+            "search.itunes.apple.com",
+            "itunes.apple.com",
+            "s3.mzstatic.com",
+            "api-edge.apps.apple.com",
+            "a5.mzstatic.com",
+            "radio-services.itunes.apple.com",
+            "s5.mzstatic.com",
+            "vocabulary.itunes.apple.com",
+            "api.music.apple.com",
+            "embed.itunes.apple.com",
+            "init.itunes.apple.com",
+            "carrierbundle.itunes.apple.com",
+            "finance-app.itunes.apple.com",
+            "uts-api-siri.itunes.apple.com",
+            "dzc-metrics.mzstatic.com",
+            "is1-ssl.mzstatic.com",
+            "accertify.mzstatic.com",
+            "files.itunes.apple.com",
+            "se-edge.itunes.apple.com",
+            "videos.apple.com",
+            "se.itunes.apple.com",
+            "sync.itunes.apple.com",
+            "edge.itunes.apple.com",
+            "b4.mzstatic.com",
+            "radio-quickplay.itunes.apple.com",
+            "bookkeeper.itunes.apple.com",
+            "podcasts.apple.com",
+            "bag.itunes.apple.com",
+            "desktop-store.itunes.apple.com",
+            "a1.mzstatic.com",
+            "su.itunes.apple.com",
+            "itunesu.itunes.apple.com",
+            "b1.mzstatic.com",
+            "a4.mzstatic.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650904069,
+          "validTo": 1685032068,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.439",
+      "timestamp": 47330.829099,
+      "dataLength": 130884,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.439",
+      "timestamp": 47330.829099,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.439",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.440",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://securemetrics.apple.com/b/ss/applestoreww/1/JS-2.22.0/s21767892672788?AQB=1&ndh=1&pf=1&t=16%2F11%2F2022%2011%3A55%3A15%205%20420&fid=494188FEBF2F6DB0-240F3FCD19EA1195&ce=UTF-8&cdp=2&cl=1800&pageName=apple%20-%20index%2Ftab%20%28us%29&g=https%3A%2F%2Fwww.apple.com%2F&r=https%3A%2F%2Fwww.apple.com%2F&cc=USD&ch=www.us.homepage&server=ac-2.16.0&events=event220%3D0.000%2Cevent221%3D0.537%2Cevent222%3D0.017%2Cevent223%3D0.145%2Cevent224%3D0.073%2Cevent225%3D0.013%2Cevent226%3D1.101%2Cevent227%3D0.003%2Cevent228%3D1.503%2Cevent229%3D2.612%2Cevent230%3D0.000%2Cevent231%3D3.396%2Cevent232%2Cevent419%3D1.915%2Cevent420&h1=www.us.homepage&v3=aos%3A%20us&l3=D%3Das_tex&c4=D%3Dg&v4=D%3DpageName&c14=apple%20-%20index%2Ftab%20%28us%29&v14=en-us&c17=15%3A15&c20=aos%3A%20us&c28=770&v49=D%3Dr&v54=D%3Dg&c57=www.us.homepage&v97=s.t-p&s=1728x1117&c=30&j=1.6&v=N&k=Y&bw=1366&bh=768&AQE=1",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.840713,
+      "wallTime": 1671216915.241559,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [],
+          "parent": {
+            "description": "Image",
+            "callFrames": [
+              {
+                "functionName": "t.$b",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 119933
+              },
+              {
+                "functionName": "t.U",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 117901
+              },
+              {
+                "functionName": "t.sb",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 115397
+              },
+              {
+                "functionName": "t.Fa",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 113244
+              },
+              {
+                "functionName": "t.t.t.track",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 113432
+              },
+              {
+                "functionName": "submit",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 197094
+              },
+              {
+                "functionName": "value",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 150358
+              },
+              {
+                "functionName": "value",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 205228
+              },
+              {
+                "functionName": "",
+                "scriptId": "47",
+                "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                "lineNumber": 0,
+                "columnNumber": 205670
+              }
+            ],
+            "parent": {
+              "description": "setTimeout",
+              "callFrames": [
+                {
+                  "functionName": "",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 205648
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 205624
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 204853
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 204484
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 266732
+                },
+                {
+                  "functionName": "value",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 265488
+                },
+                {
+                  "functionName": "r",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 265131
+                },
+                {
+                  "functionName": "onPageDataLoaded",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 232758
+                },
+                {
+                  "functionName": "initialize",
+                  "scriptId": "47",
+                  "url": "https://www.apple.com/metrics/ac-analytics/2.16.0/scripts/ac-analytics.js",
+                  "lineNumber": 0,
+                  "columnNumber": 232522
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "50",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 31089
+                },
+                {
+                  "functionName": "e.exports",
+                  "scriptId": "50",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 31117
+                },
+                {
+                  "functionName": "190.191",
+                  "scriptId": "50",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 225455
+                },
+                {
+                  "functionName": "r",
+                  "scriptId": "50",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 253
+                },
+                {
+                  "functionName": "t",
+                  "scriptId": "50",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 413
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "50",
+                  "url": "https://www.apple.com/v/home/aw/built/scripts/main.built.js",
+                  "lineNumber": 0,
+                  "columnNumber": 430
+                }
+              ]
+            }
+          }
+        }
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.440",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47331.39875,
+      "type": "Image",
+      "response": {
+        "url": "https://securemetrics.apple.com/b/ss/applestoreww/1/JS-2.22.0/s21767892672788?AQB=1&ndh=1&pf=1&t=16%2F11%2F2022%2011%3A55%3A15%205%20420&fid=494188FEBF2F6DB0-240F3FCD19EA1195&ce=UTF-8&cdp=2&cl=1800&pageName=apple%20-%20index%2Ftab%20%28us%29&g=https%3A%2F%2Fwww.apple.com%2F&r=https%3A%2F%2Fwww.apple.com%2F&cc=USD&ch=www.us.homepage&server=ac-2.16.0&events=event220%3D0.000%2Cevent221%3D0.537%2Cevent222%3D0.017%2Cevent223%3D0.145%2Cevent224%3D0.073%2Cevent225%3D0.013%2Cevent226%3D1.101%2Cevent227%3D0.003%2Cevent228%3D1.503%2Cevent229%3D2.612%2Cevent230%3D0.000%2Cevent231%3D3.396%2Cevent232%2Cevent419%3D1.915%2Cevent420&h1=www.us.homepage&v3=aos%3A%20us&l3=D%3Das_tex&c4=D%3Dg&v4=D%3DpageName&c14=apple%20-%20index%2Ftab%20%28us%29&v14=en-us&c17=15%3A15&c20=aos%3A%20us&c28=770&v49=D%3Dr&v54=D%3Dg&c57=www.us.homepage&v97=s.t-p&s=1728x1117&c=30&j=1.6&v=N&k=Y&bw=1366&bh=768&AQE=1",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "pragma": "no-cache",
+          "date": "Fri, 16 Dec 2022 18:55:15 GMT",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "x-content-type-options": "nosniff",
+          "last-modified": "Sat, 17 Dec 2022 18:55:15 GMT",
+          "server": "jag",
+          "etag": "3588910998782607360-4619749988038085347",
+          "vary": "*",
+          "p3p": "CP=\"This is not a P3P policy\"",
+          "access-control-allow-origin": "*",
+          "content-type": "image/gif;charset=utf-8",
+          "cache-control": "no-cache, no-store, max-age=0, no-transform, private",
+          "content-length": "43",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Thu, 15 Dec 2022 18:55:15 GMT"
+        },
+        "mimeType": "image/gif",
+        "connectionReused": true,
+        "connectionId": 279,
+        "remoteIPAddress": "63.140.36.121",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 249,
+        "timing": {
+          "requestTime": 47331.348385,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.196,
+          "sendEnd": 0.326,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.435
+        },
+        "responseTime": 1671216915795.461,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "securemetrics.apple.com",
+          "sanList": [
+            "securemetrics.apple.com",
+            "securemvt.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1651689708,
+          "validTo": 1685817707,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.440",
+      "timestamp": 47331.398795,
+      "dataLength": 43,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.440",
+      "timestamp": 47331.39897,
+      "dataLength": 0,
+      "encodedDataLength": 61
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.440",
+      "timestamp": 47331.396211,
+      "encodedDataLength": 310,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.440",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.440",
+      "wallTime": 1671216915.496,
+      "timestamp": 47331.09507107735
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.441",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/search-services/suggestions/defaultlinks/?src=globalnav&locale=en_US",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.845729,
+      "wallTime": 1671216915.246566,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "n.send",
+              "scriptId": "44",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 21264
+            },
+            {
+              "functionName": "ajax",
+              "scriptId": "44",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 20548
+            },
+            {
+              "functionName": "get",
+              "scriptId": "44",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 20606
+            },
+            {
+              "functionName": "h.fetchData",
+              "scriptId": "44",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 92069
+            },
+            {
+              "functionName": "u.fetchData",
+              "scriptId": "44",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 84957
+            },
+            {
+              "functionName": "v.fetchData",
+              "scriptId": "44",
+              "url": "https://www.apple.com/ac/globalnav/7/en_US/scripts/ac-globalnav.built.js",
+              "lineNumber": 0,
+              "columnNumber": 77396
+            }
+          ]
+        }
+      },
+      "redirectHasExtraInfo": false,
+      "type": "XHR",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.441",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47331.354068,
+      "type": "XHR",
+      "response": {
+        "url": "https://www.apple.com/search-services/suggestions/defaultlinks/?src=globalnav&locale=en_US",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "x-content-type-options": "nosniff",
+          "server": "Apple",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "application/json",
+          "cache-control": "max-age=272",
+          "content-length": "526",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 18:59:38 GMT"
+        },
+        "mimeType": "application/json",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 47331.34941,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.044,
+          "sendEnd": 0.044,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 3.664
+        },
+        "responseTime": 1671216906159.13,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.441",
+      "timestamp": 47331.354124,
+      "dataLength": 526,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.441",
+      "timestamp": 47331.353388,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.441",
+      "body": "testBody",
+      "base64Encoded": false
+    }
+  },
+  {
+    "method": "Custom.requestContinued",
+    "params": {
+      "requestId": "14040.441",
+      "wallTime": 1671216915.498,
+      "timestamp": 47331.09707093239
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.442",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/iphone-14/hero_iphone14__fjmsqstr1ceq_large.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.848538,
+      "wallTime": 1671216915.249351,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.442"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.442",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.848593,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/iphone-14/hero_iphone14__fjmsqstr1ceq_large.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:52 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/jpeg",
+          "cache-control": "max-age=3339",
+          "accept-ranges": "bytes",
+          "content-length": "62668",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:50:45 GMT"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 63590,
+        "timing": {
+          "requestTime": 47321.709656,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.053,
+          "sendEnd": 0.093,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 43.478
+        },
+        "responseTime": 1671216906153.934,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.442",
+      "timestamp": 47330.848602,
+      "dataLength": 62668,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.442",
+      "timestamp": 47330.848604,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.442",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.443",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/holiday-2022/memoji02/hero_startframe__dbi4flqyio2u_large.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.848652,
+      "wallTime": 1671216915.249461,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.443"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.443",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.848686,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/holiday-2022/memoji02/hero_startframe__dbi4flqyio2u_large.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:52 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/jpeg",
+          "cache-control": "max-age=1071",
+          "accept-ranges": "bytes",
+          "content-length": "23109",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:12:57 GMT"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 23932,
+        "timing": {
+          "requestTime": 47321.709878,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.039,
+          "sendEnd": 0.071,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 41.034
+        },
+        "responseTime": 1671216906151.678,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.443",
+      "timestamp": 47330.84869,
+      "dataLength": 23109,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.443",
+      "timestamp": 47330.848691,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.443",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.444",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/holiday-2022/hero_endframe__8xosbwdvpaqe_large.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.848724,
+      "wallTime": 1671216915.249532,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.444"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.444",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.848753,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/holiday-2022/hero_endframe__8xosbwdvpaqe_large.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:52 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_MEM_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/jpeg",
+          "cache-control": "max-age=1959",
+          "accept-ranges": "bytes",
+          "content-length": "36182",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:27:45 GMT"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 37041,
+        "timing": {
+          "requestTime": 47321.711458,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.046,
+          "sendEnd": 0.076,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 46.996
+        },
+        "responseTime": 1671216906159.257,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.444",
+      "timestamp": 47330.848759,
+      "dataLength": 36182,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.444",
+      "timestamp": 47330.84876,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.444",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "14040.445",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "documentURL": "https://www.apple.com/",
+      "request": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/apple-card-december/hero__dvsxv8smkkgi_large.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.apple.com/v/home/aw/built/styles/main.built.css",
+          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/107.0.5304.110 Safari/605.1.15 ObservePoint"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "isSameSite": true
+      },
+      "timestamp": 47330.848786,
+      "wallTime": 1671216915.249595,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.apple.com/v/home/aw/built/styles/main.built.css"
+      },
+      "redirectHasExtraInfo": false,
+      "type": "Image",
+      "frameId": "9393078694755F53BAA0B9EDADE69307",
+      "hasUserGesture": true
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": {
+      "requestId": "14040.445"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "14040.445",
+      "loaderId": "7FC52BF72682A528CE2FE9D47E95E8AB",
+      "timestamp": 47330.848818,
+      "type": "Image",
+      "response": {
+        "url": "https://www.apple.com/v/home/aw/images/heroes/apple-card-december/hero__dvsxv8smkkgi_large.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "strict-transport-security": "max-age=31536000; includeSubdomains",
+          "content-security-policy": "default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com",
+          "x-content-type-options": "nosniff",
+          "referrer-policy": "no-referrer-when-downgrade",
+          "last-modified": "Fri, 02 Dec 2022 01:03:51 GMT",
+          "server": "Apple",
+          "date": "Fri, 16 Dec 2022 18:55:06 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "TCP_HIT from a23-56-169-29.deploy.akamaitechnologies.com (AkamaiGHost/10.10.3-45298580) (-)",
+          "content-type": "image/jpeg",
+          "cache-control": "max-age=1551",
+          "accept-ranges": "bytes",
+          "content-length": "164456",
+          "x-xss-protection": "1; mode=block",
+          "expires": "Fri, 16 Dec 2022 19:20:57 GMT"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": true,
+        "connectionId": 13,
+        "remoteIPAddress": "23.60.171.52",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 165583,
+        "timing": {
+          "requestTime": 47321.830699,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "workerFetchStart": -1,
+          "workerRespondWithSettled": -1,
+          "sendStart": 0.375,
+          "sendEnd": 0.431,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 42.907
+        },
+        "responseTime": 1671216906274.387,
+        "protocol": "h2",
+        "alternateProtocolUsage": "unspecifiedReason",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "www.apple.com",
+          "sanList": [
+            "www.apple.com.cn",
+            "www.apple.com",
+            "images.apple.com"
+          ],
+          "issuer": "Apple Public EV Server RSA CA 2 - G1",
+          "validFrom": 1650383400,
+          "validTo": 1684511399,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown",
+          "serverSignatureAlgorithm": 2052,
+          "encryptedClientHello": false
+        }
+      },
+      "hasExtraInfo": true,
+      "frameId": "9393078694755F53BAA0B9EDADE69307"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "14040.445",
+      "timestamp": 47330.848822,
+      "dataLength": 164456,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "14040.445",
+      "timestamp": 47330.848824,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.getResponseBody",
+    "params": {
+      "requestId": "14040.445",
+      "body": "testBody",
+      "base64Encoded": true
+    }
+  }
+]


### PR DESCRIPTION
The chrome-har-capturer is designed to only return a HAR for a single page.  However, our provided logs will have events for more than one page, on occasion.  Modifying the capturer to only accept the first occurrence of Page.xxx events.  

Also adding conditional usage of a requestContinued event to help trim down the page and tag load times. when request interception is used.